### PR TITLE
Add GraphSpace dependencies to conda environment

### DIFF
--- a/.github/workflows/test-spras.yml
+++ b/.github/workflows/test-spras.yml
@@ -23,7 +23,7 @@ jobs:
 
   # Builds the Docker images
   docker:
-    name: Test Docker wrappers
+    name: Test Docker images
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -69,7 +69,7 @@ jobs:
 
   # Runs the test code and Snakemake workflow
   test:
-    name: Test Docker wrappers
+    name: Run test cases and workflow
     # This job depends on the conda job but not the docker job
     # Therefore the Docker images will be pulled in both the docker job and the test job
     needs: conda

--- a/.github/workflows/test-spras.yml
+++ b/.github/workflows/test-spras.yml
@@ -3,13 +3,13 @@ name: Test SPRAS
 on: [push, pull_request]
 
 jobs:
-  # Installs the conda environment
-  conda:
+  # Installs the conda environment but does not run tests because the tests require Linux Docker images
+  conda-only:
     name: Test conda environment
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -21,9 +21,34 @@ jobs:
         auto-activate-base: false
         miniconda-version: 'latest'
 
+  # Runs the test code and Snakemake workflow in the conda environment
+  test:
+    name: Run test cases and workflow
+    # The Docker images will be pulled in both the docker job and this test job
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Install conda environment
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        activate-environment: spras
+        environment-file: environment.yml
+        auto-activate-base: false
+        miniconda-version: 'latest'
+    - name: Run tests
+      shell: bash --login {0}
+      run: pytest
+    - name: Run Snakemake workflow
+      shell: bash --login {0}
+      run: snakemake --cores 1
+
   # Builds the Docker images
   docker:
-    name: Test Docker images
+    name: Build Docker images
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -66,21 +91,3 @@ jobs:
         tags: latest
         cache_froms: reedcompbio/pathlinker:latest
         push: false
-
-  # Runs the test code and Snakemake workflow
-  test:
-    name: Run test cases and workflow
-    # This job depends on the conda job but not the docker job
-    # Therefore the Docker images will be pulled in both the docker job and the test job
-    needs: conda
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    steps:
-    - name: Run tests
-      shell: bash --login {0}
-      run: pytest
-    - name: Run Snakemake workflow
-      shell: bash --login {0}
-      run: snakemake --cores 1

--- a/.github/workflows/test-spras.yml
+++ b/.github/workflows/test-spras.yml
@@ -1,9 +1,27 @@
-name: Test Docker wrappers
+name: Test SPRAS
 
 on: [push, pull_request]
 
 jobs:
-  # Builds the Docker images and runs their test code
+  # Installs the conda environment
+  conda:
+    name: Test conda environment
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Install conda environment
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        activate-environment: spras
+        environment-file: environment.yml
+        auto-activate-base: false
+        miniconda-version: 'latest'
+
+  # Builds the Docker images
   docker:
     name: Test Docker wrappers
     runs-on: ${{ matrix.os }}
@@ -48,13 +66,18 @@ jobs:
         tags: latest
         cache_froms: reedcompbio/pathlinker:latest
         push: false
-    - name: Install conda environment
-      uses: conda-incubator/setup-miniconda@v2
-      with:
-        activate-environment: spras
-        environment-file: environment.yml
-        auto-activate-base: false
-        miniconda-version: 'latest'
+
+  # Runs the test code and Snakemake workflow
+  test:
+    name: Test Docker wrappers
+    # This job depends on the conda job but not the docker job
+    # Therefore the Docker images will be pulled in both the docker job and the test job
+    needs: conda
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    steps:
     - name: Run tests
       shell: bash --login {0}
       run: pytest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Signaling Pathway Reconstruction Analysis Streamliner (SPRAS)
-[![Test Docker wrappers](https://github.com/Reed-CompBio/spras/actions/workflows/test-docker-wrappers.yml/badge.svg)](https://github.com/Reed-CompBio/spras/actions/workflows/test-docker-wrappers.yml)
+[![Test SPRAS](https://github.com/Reed-CompBio/spras/actions/workflows/test-spras.yml/badge.svg)](https://github.com/Reed-CompBio/spras/actions/workflows/test-spras.yml)
 
 SPRAS is a work-in-progress dockerized library of pathway reconstruction enhancement tools.
 The framework will contain different pathway reconstruction algorithms that connect genes and proteins of interest in the context of a general protein-protein interaction network, allowing users to run multiple algorithms on their inputs.

--- a/environment.yml
+++ b/environment.yml
@@ -9,5 +9,8 @@ dependencies:
   - pytest=6.2
   - python=3.8
   - pip=21.1.1
+  # Only required for GraphSpace
+  - jinja2=2.10
+  - sphinx=4.0
   - pip:
      - git+https://github.com/annaritz/graphspace-python@fa9bb4b0adc54de50a956daade82db48a8030f64

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,6 @@ dependencies:
   - jinja2=2.10
   - mock=4.0
   - recommonmark=0.7
-  - requests=2.10.0
   - sphinx=4.0
   - pip:
      - git+https://github.com/annaritz/graphspace-python@fa9bb4b0adc54de50a956daade82db48a8030f64

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - pytest=6.2
   - python=3.8
   - pip=21.1.1
-  - requests=2.20.0
+  - requests=2.26
   # Only required for GraphSpace
   - commonmark=0.9
   - docutils=0.16
@@ -18,5 +18,5 @@ dependencies:
   - recommonmark=0.7
   - sphinx=4.0
   - pip:
-     - graphspace_python==1.3.0
+     - git+https://github.com/agitter/graphspace-python@1cd57454a8005d76dcd365270c709d25e9bb54aa
      - sphinx-rtd-theme==0.5.2

--- a/environment.yml
+++ b/environment.yml
@@ -11,9 +11,12 @@ dependencies:
   - pip=21.1.1
   # Only required for GraphSpace
   - commonmark=0.9
-  - docutils=0.17
+  - docutils=0.16
   - jinja2=2.10
+  - mock=4.0
   - recommonmark=0.7
+  - requests=2.10.0
   - sphinx=4.0
   - pip:
      - git+https://github.com/annaritz/graphspace-python@fa9bb4b0adc54de50a956daade82db48a8030f64
+     - sphinx-rtd-theme==0.5.2

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,10 @@ dependencies:
   - python=3.8
   - pip=21.1.1
   # Only required for GraphSpace
+  - commonmark=0.9
+  - docutils=0.17
   - jinja2=2.10
+  - recommonmark=0.7
   - sphinx=4.0
   - pip:
      - git+https://github.com/annaritz/graphspace-python@fa9bb4b0adc54de50a956daade82db48a8030f64

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - pytest=6.2
   - python=3.8
   - pip=21.1.1
+  - requests=2.20.0
   # Only required for GraphSpace
   - commonmark=0.9
   - docutils=0.16
@@ -17,8 +18,5 @@ dependencies:
   - recommonmark=0.7
   - sphinx=4.0
   - pip:
-     - git+https://github.com/annaritz/graphspace-python@fa9bb4b0adc54de50a956daade82db48a8030f64
-     # GraphSpace requires a specific version of requests
-     # https://github.com/adbharadwaj/graphspace-python/blob/42283556eb3a52212cfa9f75dfc694c70069add7/requirements.txt#L3
-     - requests==2.10.0
+     - graphspace_python==1.3.0
      - sphinx-rtd-theme==0.5.2

--- a/environment.yml
+++ b/environment.yml
@@ -18,5 +18,5 @@ dependencies:
   - recommonmark=0.7
   - sphinx=4.0
   - pip:
-     - git+https://github.com/agitter/graphspace-python@1cd57454a8005d76dcd365270c709d25e9bb54aa
+     - graphspace_python==1.3.1
      - sphinx-rtd-theme==0.5.2

--- a/environment.yml
+++ b/environment.yml
@@ -18,4 +18,7 @@ dependencies:
   - sphinx=4.0
   - pip:
      - git+https://github.com/annaritz/graphspace-python@fa9bb4b0adc54de50a956daade82db48a8030f64
+     # GraphSpace requires a specific version of requests
+     # https://github.com/adbharadwaj/graphspace-python/blob/42283556eb3a52212cfa9f75dfc694c70069add7/requirements.txt#L3
+     - requests==2.10.0
      - sphinx-rtd-theme==0.5.2


### PR DESCRIPTION
Closes #30

I listed the new packages separately so that we can remove them later if we decide to Dockerize GraphSpace.

@annaritz do you know whether GraphSpace needs version 2.10.0 of the requests package specifically?  Only that version is allowed in https://github.com/adbharadwaj/graphspace-python/blob/42283556eb3a52212cfa9f75dfc694c70069add7/requirements.txt#L3.  That prevents us from installing it through conda.  It is so old it conflicts with other packages in our environment.  It may also be throwing warnings in our test code
```
test/OmicsIntegrator1/test_oi1.py::TestOmicsIntegrator1::test_oi1_required
  /usr/share/miniconda3/envs/spras/lib/python3.8/site-packages/requests/models.py:170: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    if isinstance(hook, collections.Callable):
```

I also split the monolithic test workflow into three jobs that can run in parallel.  Building the Docker images is tested independently from testing the conda environment and running the test code.  The conda environment job also runs in Linux, macOS, and Windows so we can confirm SPRAS can be installed on any platform.  The tests only run in Linux.