### PR TITLE
Add checkpoints to Snakemake workflow

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -22,9 +22,10 @@ def get_dataset_dependencies(datasets, label):
     all_files = dataset["node_files"] + dataset["edge_files"] + dataset["other_files"]
     # Add the relative file path and config file
     all_files = [os.path.join(dataset["data_dir"], data_file) for data_file in all_files]
-    return all_files + [os.path.join(out_dir, f'datasets-{dataset}.yaml')]
+    return all_files + [os.path.join(out_dir, f'datasets-{label}.yaml')]
 
 algorithms = list(algorithm_params)
+dataset_labels = list(datasets.keys())
 
 # Generate numeric indices for the parameter combinations
 # of each reconstruction algorithms
@@ -73,21 +74,21 @@ def make_final_input(wildcards):
     #TODO analysis could be parsed in the parse_config() function.
     if config["analysis"]["summary"]["include"]:
         # add summary output file.
-        final_input.extend(expand('{out_dir}{sep}summary-{dataset}-{algorithm_params}.txt',out_dir=out_dir,sep=os.sep,dataset=datasets,algorithm_params=algorithms_with_params))
+        final_input.extend(expand('{out_dir}{sep}summary-{dataset}-{algorithm_params}.txt',out_dir=out_dir,sep=os.sep,dataset=dataset_labels,algorithm_params=algorithms_with_params))
 
     if config["analysis"]["graphspace"]["include"]:
         # add graph and style JSON files.
-        final_input.extend(expand('{out_dir}{sep}gs-{dataset}-{algorithm_params}.json',out_dir=out_dir,sep=os.sep,dataset=datasets,algorithm_params=algorithms_with_params))
-        final_input.extend(expand('{out_dir}{sep}gsstyle-{dataset}-{algorithm_params}.json',out_dir=out_dir,sep=os.sep,dataset=datasets,algorithm_params=algorithms_with_params))
+        final_input.extend(expand('{out_dir}{sep}gs-{dataset}-{algorithm_params}.json',out_dir=out_dir,sep=os.sep,dataset=dataset_labels,algorithm_params=algorithms_with_params))
+        final_input.extend(expand('{out_dir}{sep}gsstyle-{dataset}-{algorithm_params}.json',out_dir=out_dir,sep=os.sep,dataset=dataset_labels,algorithm_params=algorithms_with_params))
 
     if len(final_input) == 0:
         # No analysis added yet, so add reconstruction output files if they exist.
         # (if analysis is specified, these should be implicity run).
-        final_input.extend(expand('{out_dir}{sep}pathway-{dataset}-{algorithm_params}.txt', out_dir=out_dir, sep=os.sep, dataset=datasets, algorithm_params=algorithms_with_params))
+        final_input.extend(expand('{out_dir}{sep}pathway-{dataset}-{algorithm_params}.txt', out_dir=out_dir, sep=os.sep, dataset=dataset_labels, algorithm_params=algorithms_with_params))
 
     # Create log files for the parameters and datasets
     final_input.extend(expand('{out_dir}{sep}parameters-{algorithm}.yaml', out_dir=out_dir, sep=os.sep, algorithm=algorithms))
-    final_input.extend(expand('{out_dir}{sep}datasets-{dataset}.yaml', out_dir=out_dir, sep=os.sep, dataset=datasets))
+    final_input.extend(expand('{out_dir}{sep}datasets-{dataset}.yaml', out_dir=out_dir, sep=os.sep, dataset=dataset_labels))
 
     return final_input
 
@@ -113,7 +114,7 @@ checkpoint check_cached_parameter_log:
     # A Snakemake flag file
     output: touch(os.path.join(out_dir, '.parameters-{algorithm}.flag'))
     run:
-        logfile = os.path.join(out_dir, f'parameters-{wildcards.algorithm}.txt')
+        logfile = os.path.join(out_dir, f'parameters-{wildcards.algorithm}.yaml')
         # TODO remove print statements before merging but include for now to illustrate the workflow
         print(f'Cached logfile: {logfile}')
 
@@ -259,7 +260,7 @@ def collect_prepared_input(wildcards):
 
     # The reconstruct rule also depends on the parameters
     # Add the parameter logfile to the list of inputs so that the reconstruct rule is executed if the parameters change
-    prepared_inputs.append(os.path.join(out_dir, f'parameters-{wildcards.algorithm}.txt'))
+    prepared_inputs.append(os.path.join(out_dir, f'parameters-{wildcards.algorithm}.yaml'))
     return prepared_inputs
 
 # Run the pathway reconstruction algorithm

--- a/Snakefile
+++ b/Snakefile
@@ -217,7 +217,7 @@ def get_dataset_dependencies(wildcards):
 
     dataset = datasets[wildcards.dataset]
     all_files = dataset["node_files"] + dataset["edge_files"] + dataset["other_files"]
-    # Add the relative file path and config file
+    # Add the relative file path and dataset logfile
     all_files = [os.path.join(dataset["data_dir"], data_file) for data_file in all_files]
     return all_files + [out_dir + SEP + f'datasets-{wildcards.dataset}.yaml']
 
@@ -285,7 +285,7 @@ def collect_prepared_input(wildcards):
 
     # The reconstruct rule also depends on the parameters
     # Add the parameter logfile to the list of inputs so that the reconstruct rule is executed if the parameters change
-    prepared_inputs.append(out_dir + SEP + f'parameters-{wildcards.algorithm}.yaml'   )
+    prepared_inputs.append(out_dir + SEP + f'parameters-{wildcards.algorithm}.yaml')
     return prepared_inputs
 
 # Run the pathway reconstruction algorithm

--- a/Snakefile
+++ b/Snakefile
@@ -6,6 +6,9 @@ from src.util import parse_config
 from src.analysis.summary import summary
 from src.analysis.viz import graphspace
 
+# TODO decide whether to use os.sep os.altsep or a fixed character for file paths
+SEP = '/'
+
 config_file = os.path.join('config', 'config.yaml')
 
 config, datasets, out_dir, algorithm_params, algorithm_directed = parse_config(config_file)
@@ -74,21 +77,21 @@ def make_final_input(wildcards):
     #TODO analysis could be parsed in the parse_config() function.
     if config["analysis"]["summary"]["include"]:
         # add summary output file.
-        final_input.extend(expand('{out_dir}{sep}summary-{dataset}-{algorithm_params}.txt',out_dir=out_dir,sep=os.sep,dataset=dataset_labels,algorithm_params=algorithms_with_params))
+        final_input.extend(expand('{out_dir}{sep}summary-{dataset}-{algorithm_params}.txt',out_dir=out_dir,sep=SEP,dataset=dataset_labels,algorithm_params=algorithms_with_params))
 
     if config["analysis"]["graphspace"]["include"]:
         # add graph and style JSON files.
-        final_input.extend(expand('{out_dir}{sep}gs-{dataset}-{algorithm_params}.json',out_dir=out_dir,sep=os.sep,dataset=dataset_labels,algorithm_params=algorithms_with_params))
-        final_input.extend(expand('{out_dir}{sep}gsstyle-{dataset}-{algorithm_params}.json',out_dir=out_dir,sep=os.sep,dataset=dataset_labels,algorithm_params=algorithms_with_params))
+        final_input.extend(expand('{out_dir}{sep}gs-{dataset}-{algorithm_params}.json',out_dir=out_dir,sep=SEP,dataset=dataset_labels,algorithm_params=algorithms_with_params))
+        final_input.extend(expand('{out_dir}{sep}gsstyle-{dataset}-{algorithm_params}.json',out_dir=out_dir,sep=SEP,dataset=dataset_labels,algorithm_params=algorithms_with_params))
 
     if len(final_input) == 0:
         # No analysis added yet, so add reconstruction output files if they exist.
         # (if analysis is specified, these should be implicity run).
-        final_input.extend(expand('{out_dir}{sep}pathway-{dataset}-{algorithm_params}.txt', out_dir=out_dir, sep=os.sep, dataset=dataset_labels, algorithm_params=algorithms_with_params))
+        final_input.extend(expand('{out_dir}{sep}pathway-{dataset}-{algorithm_params}.txt', out_dir=out_dir, sep=SEP, dataset=dataset_labels, algorithm_params=algorithms_with_params))
 
     # Create log files for the parameters and datasets
-    final_input.extend(expand('{out_dir}{sep}parameters-{algorithm}.yaml', out_dir=out_dir, sep=os.sep, algorithm=algorithms))
-    final_input.extend(expand('{out_dir}{sep}datasets-{dataset}.yaml', out_dir=out_dir, sep=os.sep, dataset=dataset_labels))
+    final_input.extend(expand('{out_dir}{sep}parameters-{algorithm}.yaml', out_dir=out_dir, sep=SEP, algorithm=algorithms))
+    final_input.extend(expand('{out_dir}{sep}datasets-{dataset}.yaml', out_dir=out_dir, sep=SEP, dataset=dataset_labels))
 
     return final_input
 

--- a/Snakefile
+++ b/Snakefile
@@ -87,8 +87,8 @@ def make_final_input(wildcards):
         final_input.extend(expand('{out_dir}{sep}pathway-{dataset}-{algorithm_params}.txt', out_dir=out_dir, sep=os.sep, dataset=datasets, algorithm_params=algorithms_with_params))
 
     # Create log files for the parameters and datasets
-    final_input.extend(expand('{out_dir}{sep}parameters-{algorithm}.txt', out_dir=out_dir, sep=os.sep, algorithm=algorithms))
-    final_input.extend(expand('{out_dir}{sep}datasets-{dataset}.txt', out_dir=out_dir, sep=os.sep, dataset=datasets))
+    final_input.extend(expand('{out_dir}{sep}parameters-{algorithm}.yaml', out_dir=out_dir, sep=os.sep, algorithm=algorithms))
+    final_input.extend(expand('{out_dir}{sep}datasets-{dataset}.yaml', out_dir=out_dir, sep=os.sep, dataset=datasets))
 
     return final_input
 
@@ -144,7 +144,7 @@ rule log_parameters:
     # Therefore, this rule is triggered when the output file is missing but not when the input flag has been updated,
     # which happens every time any part of the config file is updated
     input: ancient(os.path.join(out_dir, '.parameters-{algorithm}.flag'))
-    output: logfile = os.path.join(out_dir, 'parameters-{algorithm}.txt')
+    output: logfile = os.path.join(out_dir, 'parameters-{algorithm}.yaml')
     run:
         write_parameter_log(wildcards.algorithm, output.logfile)
 
@@ -163,7 +163,7 @@ checkpoint check_cached_dataset_log:
     # A Snakemake flag file
     output: touch(os.path.join(out_dir, '.datasets-{dataset}.flag'))
     run:
-        logfile = os.path.join(out_dir, f'datasets-{wildcards.dataset}.txt')
+        logfile = os.path.join(out_dir, f'datasets-{wildcards.dataset}.yaml')
         # TODO remove print statements before merging but include for now to illustrate the workflow
         print(f'Cached logfile: {logfile}')
 
@@ -191,7 +191,7 @@ rule log_datasets:
     # Therefore, this rule is triggered when the output file is missing but not when the input flag has been updated,
     # which happens every time any part of the config file is updated
     input: ancient(os.path.join(out_dir,'.datasets-{dataset}.flag'))
-    output: logfile = os.path.join(out_dir, 'datasets-{dataset}.txt')
+    output: logfile = os.path.join(out_dir, 'datasets-{dataset}.yaml')
     run:
         write_dataset_log(wildcards.dataset, output.logfile)
 

--- a/Snakefile
+++ b/Snakefile
@@ -216,7 +216,7 @@ rule merge_input:
 checkpoint prepare_input:
     input: dataset_file = os.path.join(out_dir, '{dataset}-merged.pickle')
     # Output is a directory that will contain all prepared files for pathway reconstruction
-    output: output_dir = directory(os.path.join(out_dir, 'prepared', '{dataset}-{algorithm}'))
+    output: output_dir = directory(os.path.join(out_dir, 'prepared', '{dataset}-{algorithm}-inputs'))
     # Run the preprocessing script for this algorithm
     run:
         # Make sure the output subdirectories exist
@@ -224,7 +224,7 @@ checkpoint prepare_input:
         # Use the algorithm's generate_inputs function to load the merged dataset, extract the relevant columns,
         # and write the output files specified by required_inputs
         # The filename_map provides the output file path for each required input file type
-        filename_map = {input_type: os.path.join(out_dir, 'prepared', f'{wildcards.dataset}-{wildcards.algorithm}', f'{input_type}.txt') for input_type in PRRunner.get_required_inputs(wildcards.algorithm)}
+        filename_map = {input_type: os.path.join(out_dir, 'prepared', f'{wildcards.dataset}-{wildcards.algorithm}-inputs', f'{input_type}.txt') for input_type in PRRunner.get_required_inputs(wildcards.algorithm)}
         PRRunner.prepare_inputs(wildcards.algorithm, input.dataset_file, filename_map)
 
 # Collect the prepared input files from the specified directory
@@ -239,7 +239,7 @@ checkpoint prepare_input:
 def collect_prepared_input(wildcards):
     # Need to construct the path in advance because it is needed before it can be obtained from the output
     # of prepare_input
-    prepared_dir = os.path.join(out_dir, 'prepared', f'{wildcards.dataset}-{wildcards.algorithm}')
+    prepared_dir = os.path.join(out_dir, 'prepared', f'{wildcards.dataset}-{wildcards.algorithm}-inputs')
 
     # Construct the list of expected prepared input files for the reconstruction algorithm
     prepared_inputs = expand(os.path.join(prepared_dir,'{type}.txt'),type=PRRunner.get_required_inputs(algorithm=wildcards.algorithm))

--- a/Snakefile
+++ b/Snakefile
@@ -130,7 +130,7 @@ checkpoint check_cached_parameter_log:
 
         print(f'Current params: {cur_params_dict}')
         print(f'Cached params: {cached_params_dict}')
-        if cur_params_dict != cached_params_dict:
+        if cur_params_dict != cached_params_dict and os.path.isfile(logfile):
             print(f'Deleting stale {logfile}')
             os.remove(logfile)
         # TODO remove when removing print statements

--- a/Snakefile
+++ b/Snakefile
@@ -1,7 +1,3 @@
-# With Git Bash on Windows multiline strings are not executed properly
-# https://carpentries-incubator.github.io/workflows-snakemake/07-resources/index.html
-# (No longer applicable for this command, but a good reminder)
-
 import os
 import PRRunner
 import shutil
@@ -10,8 +6,6 @@ from src.analysis.summary import summary
 from src.analysis.viz import graphspace
 
 config_file = os.path.join('config', 'config.yaml')
-wildcard_constraints:
-    algorithm='\w+'
 
 config, datasets, out_dir, algorithm_params, algorithm_directed = parse_config(config_file)
 

--- a/Snakefile
+++ b/Snakefile
@@ -54,17 +54,18 @@ def write_parameter_log(algorithm, logfile):
     with open(logfile,'w') as f:
         yaml.safe_dump(cur_params_dict,f)
 
-# Read the cached algorithm parameters from a yaml logfile
-def read_parameter_log(logfile):
+# Read the cached algorithm parameters or dataset contents from a yaml logfile
+def read_yaml_log(logfile):
     with open(logfile) as f:
         return yaml.safe_load(f)
 
-# Log the datasets specified in the config file.
-# TODO switch to yaml and add caching
-def write_dataset_log(dataset,logfile):
+# Log the dataset contents specified in the config file in a yaml file
+def write_dataset_log(dataset, logfile):
+    dataset_contents = get_dataset(datasets,dataset)
+
+    print(f'Writing {logfile}')
     with open(logfile,'w') as f:
-        for key,value in datasets[dataset].items():
-            f.write(f'{key}: {value}\n')
+        yaml.safe_dump(dataset_contents,f)
 
 # Choose the final files expected according to the config file options.
 def make_final_input(wildcards):
@@ -123,7 +124,7 @@ checkpoint check_cached_parameter_log:
 
         # Read the cached parameters from the logfile if it exists and is readable
         try:
-            cached_params_dict = read_parameter_log(logfile)
+            cached_params_dict = read_yaml_log(logfile)
         except OSError as e:
             print(e)
             cached_params_dict = {}
@@ -170,7 +171,7 @@ checkpoint check_cached_dataset_log:
 
         # Read the cached dataset from the logfile if it exists and is readable
         try:
-            cached_dataset_dict = read_dataset_log(logfile)
+            cached_dataset_dict = read_yaml_log(logfile)
         except OSError as e:
             print(e)
             cached_dataset_dict = {}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -24,11 +24,12 @@
                 include: true
                 directed: true
                 run1:
-                    k: range(100,201,100)
+                    #k: range(100,201,100)
+                    k: [100]
 
         - name: "omicsintegrator1"
           params:
-                include: true
+                include: false
                 directed: false
                 run1:
                     r: [5]
@@ -39,7 +40,7 @@
 
         - name: "omicsintegrator2"
           params:
-                include: true
+                include: false
                 directed: false
                 run1:
                     b: [4]
@@ -60,14 +61,14 @@
        other_files: []
        # Relative path from the spras directory
        data_dir: "input"
-     -
-       label: data1
+     #-
+     #  label: data1
        # Reuse some of the same sources file as 'data0' but different network and targets
-       node_files: ["sources.txt", "alternative-targets.txt"]
-       edge_files: ["alternative-network.txt"]
-       other_files: []
+     #  node_files: ["sources.txt", "alternative-targets.txt"]
+     #  edge_files: ["alternative-network.txt"]
+     #  other_files: []
        # Relative path from the spras directory
-       data_dir: "input"
+     #  data_dir: "input"
 
  # If we want to reconstruct then we should set run to true.
  # TODO: if include is true above but run is false here, algs are not run.
@@ -85,8 +86,8 @@
  analysis:
         summary:
 
-          include: true
+          include: false
 
         graphspace:
 
-          include: true
+          include: false

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: spras
 channels:
   - conda-forge
 dependencies:
-  - bioconda::snakemake-minimal=5.32
+  - bioconda::snakemake-minimal=6.5.1
   - docker-py=5.0
   - networkx=2.5
   - pandas=1.2

--- a/src/util.py
+++ b/src/util.py
@@ -47,6 +47,7 @@ def parse_config(config_file):
     # Need to work more on input file naming to make less strict assumptions
     # about the filename structure
     # Currently assumes all datasets have a label and the labels are unique
+    # TODO may want to sort the lists of files so that there are fewer cache misses
     datasets = {dataset["label"]: dataset for dataset in config["datasets"]}
     config["datasets"] = datasets
 

--- a/test/OmicsIntegrator1/test_oi1.py
+++ b/test/OmicsIntegrator1/test_oi1.py
@@ -25,7 +25,10 @@ class TestOmicsIntegrator1:
                              output_file=TEST_DIR+'output/test_optimalForest.sif',
                              w=5,
                              b=1,
-                             d=10)
+                             d=10,
+                             noise=0.333,
+                             g=0.001,
+                             r=0)
 
     def test_oi1_all_optional(self):
         # Include all optional arguments

--- a/test_prepare_inputs.py
+++ b/test_prepare_inputs.py
@@ -9,8 +9,8 @@ with open(config_loc) as config_file:
     config = yaml.load(config_file, Loader=yaml.FullLoader)
 test_file = "test_pickled_dataset.pkl"
 
-for i in [0,1]:
-    PRRunner.merge_input(config["datasets"][i], test_file)
+for dataset in config["datasets"]:
+    PRRunner.merge_input(dataset, test_file)
     os.makedirs("tmp_output", exist_ok=True) #it is assumed directories will be made upstream
 
 #Test pathlinker


### PR DESCRIPTION
Closes #15
Closes #17

This pull request moves away from the deprecated `dynamic` feature of Snakemake and uses checkpoints to prepare multiple input files with a single rule.  The rule now produces a directory as output so it only runs once time instead of one time for each input file (e.g. node file, network file).

It also adds checkpoints to have rules depend on only parts of the config file.  Previously, updating any part of the config file would indicate to downstream rules that an upstream file changed, so all rules would be rerun.  Now, the dataset and parameters logfiles are used to cache the last dataset contents and parameter combinations.  Snakemake only needs to rerun an algorithm on a dataset if the algorithm parameters or the dataset contents changed.  Otherwise, the results of those runs can stay the same even if other parts of the config file were changed.  This could help if a user performs a large parameter sweep and then wants to modify the post-processing steps that are performed without rerunning all of the pathway reconstruction steps.

To support file caching, the parameter and dataset logfiles are now written as yaml files.  That makes it easy to read them and compare the cached settings to the current settings in the config file.

Checkpoints seemed to have bugs in the version of Snakemake we were using, so this updates to the latest version 6.5.1.  6.5.0 changed Windows file path behavior, so I now use `SEP` as a hard-coded file separator instead of `os.path.join` in some places.  Snakemake can no longer match file paths correctly on Windows with `os.path.join` or the `os.sep` character.

There are still some minor bugs with the checkpoints.  It is possible to get the output files in a state where Snakemake reruns the `prepare_input` rule every time it is executed even though no input files or config file sections change.  I'll post more instructions for testing once that is resolved.