### PR TITLE
Switch PathLinker image to Alpine Python

### DIFF
--- a/docker-wrappers/PathLinker/Dockerfile
+++ b/docker-wrappers/PathLinker/Dockerfile
@@ -1,22 +1,21 @@
 # PathLinker wrapper
 # https://github.com/Murali-group/PathLinker
-# Activates the conda environment before running command inside container
-# Uses the strategy from https://pythonspeed.com/articles/activate-conda-dockerfile/
-# by Itamar Turner-Trauring
-FROM continuumio/miniconda3:4.9.2
+FROM python:3.5.10-alpine
 
-# Required for the envsubst command
-RUN apt-get -qq update && \
-    apt-get install -y gettext-base
+# gettext is required for the envsubst command
+# See https://github.com/haskell/cabal/issues/6126 regarding wget
+RUN apk add --no-cache ca-certificates gettext wget
 
-COPY environment.yml .
-RUN conda env create -f environment.yml
-
-WORKDIR /home
+WORKDIR /PathLinker
 COPY pathlinker-files.txt .
+
+# Replace the template variable for the commit with the specific commit in the command below
+# Download that version of the PathLinker files from GitHub, including requirements.txt
+# Remove pkg-resources from requirements.txt, which cannot be installed
+# Install the required Python packages with pip
 RUN export PATHLINKER_COMMIT_SHA=d4a44c9f44f4afe30fd945015d84c1ce8c602c00 && \
     envsubst '${PATHLINKER_COMMIT_SHA}' < pathlinker-files.txt > pathlinker-files-versioned.txt && \
     rm pathlinker-files.txt && \
-    wget --input-file pathlinker-files-versioned.txt
-
-ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "pathlinker"]
+    wget --input-file pathlinker-files-versioned.txt && \
+    sed -i '/pkg-resources/d' requirements.txt && \
+    pip install -r requirements.txt

--- a/docker-wrappers/PathLinker/README.md
+++ b/docker-wrappers/PathLinker/README.md
@@ -2,13 +2,6 @@
 
 A Docker image for [PathLinker](https://github.com/Murali-group/PathLinker) that is available on [DockerHub](https://hub.docker.com/repository/docker/reedcompbio/pathlinker).
 
-## Activating conda inside a Docker container
-
-By default, an installed conda environment will not be activated inside the Docker container.
-Docker does not invoke Bash as a login shell.
-[This blog post](https://pythonspeed.com/articles/activate-conda-dockerfile/) provides a workaround demonstrated here in `Dockerfile` and `env.yml`.
-It defines a custom ENTRYPOINT that uses `conda run` to run the command inside the conda environment.
-
 To create the Docker image run:
 ```
 docker build -t reedcompbio/pathlinker -f Dockerfile .
@@ -17,7 +10,7 @@ from this directory.
 
 To confirm that commands are run inside the conda environment run:
 ```
-winpty docker run reedcompbio/pathlinker conda list
+winpty docker run reedcompbio/pathlinker pip list
 ```
 The `winpty` prefix is only needed on Windows.
 
@@ -29,4 +22,3 @@ The Docker wrapper can be tested with `pytest`.
 ## TODO
 - Attribute https://github.com/Murali-group/PathLinker
 - Document usage
-- Consider `continuumio/miniconda3:4.9.2-alpine` base image

--- a/docker-wrappers/PathLinker/README.md
+++ b/docker-wrappers/PathLinker/README.md
@@ -8,7 +8,7 @@ docker build -t reedcompbio/pathlinker -f Dockerfile .
 ```
 from this directory.
 
-To confirm that commands are run inside the conda environment run:
+To inspect the installed Python packages:
 ```
 winpty docker run reedcompbio/pathlinker pip list
 ```

--- a/docker-wrappers/PathLinker/environment.yml
+++ b/docker-wrappers/PathLinker/environment.yml
@@ -1,5 +1,0 @@
-name: pathlinker
-dependencies:
-  - decorator=4.1.2
-  - networkx=1.11
-  - python=3.5

--- a/docker-wrappers/PathLinker/pathlinker-files.txt
+++ b/docker-wrappers/PathLinker/pathlinker-files.txt
@@ -4,3 +4,4 @@ https://raw.githubusercontent.com/Murali-group/PathLinker/$PATHLINKER_COMMIT_SHA
 https://raw.githubusercontent.com/Murali-group/PathLinker/$PATHLINKER_COMMIT_SHA/ksp_Astar.py
 https://raw.githubusercontent.com/Murali-group/PathLinker/$PATHLINKER_COMMIT_SHA/parse.py
 https://raw.githubusercontent.com/Murali-group/PathLinker/$PATHLINKER_COMMIT_SHA/run.py
+https://raw.githubusercontent.com/Murali-group/PathLinker/$PATHLINKER_COMMIT_SHA/requirements.txt

--- a/src/pathlinker.py
+++ b/src/pathlinker.py
@@ -76,7 +76,7 @@ class PathLinker(PRM):
         # When renaming the output file, the output directory must already exist
         Path(work_dir, out_dir).mkdir(parents=True, exist_ok=True)
 
-        command = ['python', '/home/run.py', '/home/spras/'+network_file.as_posix(), 
+        command = ['python', '/PathLinker/run.py', '/home/spras/'+network_file.as_posix(), 
                         '/home/spras/'+node_file.as_posix()]
 
         # Add optional argument

--- a/src/pathlinker.py
+++ b/src/pathlinker.py
@@ -84,11 +84,11 @@ class PathLinker(PRM):
             command.extend(['-k', str(k)])
 
         #Don't perform this step on systems where permissions aren't an issue like windows
-        need_chown = True
-        try:
-            uid = os.getuid()
-        except AttributeError:
-            need_chown = False
+        #need_chown = True
+        #try:
+        #    uid = os.getuid()
+        #except AttributeError:
+        #    need_chown = False
 
         try:
             container_output = client.containers.run(
@@ -100,16 +100,16 @@ class PathLinker(PRM):
                 },
                 working_dir='/home/spras/')
             print(container_output.decode('utf-8'))
-            if need_chown:
+            #if need_chown:
                 #This command changes the ownership of output files so we don't
                 # get a permissions error when snakemake tries to touch the files
                 # PathLinker writes output files to the working directory
-                chown_command = " ".join(['chown',str(uid),'/home/spras/out*-ranked-edges.txt'])
-                client.containers.run('reedcompbio/pathlinker',
-                                      chown_command,
-                                      stderr=True,
-                                      volumes={prepare_path_docker(work_dir): {'bind': '/home/spras', 'mode': 'rw'}},
-                                      working_dir='/home/spras/')
+                #chown_command = " ".join(['chown',str(uid),'/home/spras/out*-ranked-edges.txt'])
+                #client.containers.run('reedcompbio/pathlinker',
+                #                      chown_command,
+                #                      stderr=True,
+                #                      volumes={prepare_path_docker(work_dir): {'bind': '/home/spras', 'mode': 'rw'}},
+                #                      working_dir='/home/spras/')
 
         finally:
             # Not sure whether this is needed

--- a/src/pathlinker.py
+++ b/src/pathlinker.py
@@ -104,7 +104,7 @@ class PathLinker(PRM):
                 #This command changes the ownership of output files so we don't
                 # get a permissions error when snakemake tries to touch the files
                 # PathLinker writes output files to the working directory
-                chown_command = " ".join(['chown',str(uid),'./out*-ranked-edges.txt'])
+                chown_command = " ".join(['chown',str(uid),'/home/spras/out*-ranked-edges.txt'])
                 client.containers.run('reedcompbio/pathlinker',
                                       chown_command,
                                       stderr=True,


### PR DESCRIPTION
The updated Dockerfile no longer uses conda to create the environment, which also eliminates the custom ENTRYPOINT.  I'm using the Alpine version of Python, which leads to smaller images.  Our current conda-based image is 303.53 MB.  This one is 21.61 MB.

Another change is that I'm downloading the `requirements.txt` from PathLinker's GitHub repository instead of tracking the required package versions here.  I have to remove the last line from the `requirements.txt` file because it isn't a valid Python package.

If the tests pass, I'll merge this and then sync it with #49.