### PR TITLE
Fix bug in Omics Integrator 1 TMPDIR

### DIFF
--- a/src/omicsintegrator1.py
+++ b/src/omicsintegrator1.py
@@ -148,7 +148,7 @@ class OmicsIntegrator1(PRM):
                             command,
                             volumes,
                             work_dir,
-                            'TMPDIR=/OmicsIntegrator1')
+                            f'TMPDIR={mapped_out_dir}')
         print(out)
 
         conf_file_local.unlink(missing_ok=True)


### PR DESCRIPTION
Closes #60

This bug was introduced in #49.  Previously volumes were mapped such that `/OmicsIntegrator1` inside the container corresponded to the root of the `spras` repository on the local filesystem, which made it a suitable temporary directory for Omics Integrator 1.  That is no longer the case.

Now the temporary directory is set to the output directory for this Omics Integrator 1 run.  I was able to reproduce #60, and this change fixed it for me.