### PR TITLE
Migrate GitHub Actions to Apptainer

### DIFF
--- a/.github/workflows/test-spras.yml
+++ b/.github/workflows/test-spras.yml
@@ -47,10 +47,12 @@ jobs:
     - name: Log conda environment
       shell: bash --login {0}
       run: conda list
-    - name: Install Singularity
-      uses: eWaterCycle/setup-singularity@v7
+    # Formerly used Singularity instead of Apptainer (see https://github.com/eWaterCycle/setup-singularity/issues/6)
+    - name: Install Apptainer
+      uses: eWaterCycle/setup-apptainer@v2
       with:
-        singularity-version: 3.8.3
+        # Choose version from https://github.com/apptainer/apptainer/releases
+        apptainer-version: 1.1.3
     - name: Run tests
       shell: bash --login {0}
       # Verbose output and disable stdout and stderr capturing


### PR DESCRIPTION
The version of "Singularity" that joined the Linux Foundation is known as Apptainer. This pull request migrates our GitHub Actions workflow to install Apptainer.

My expectation is that Apptainer currently uses symlinks so that we can continue running `singularity` commands: https://apptainer.org/docs/user/main/singularity_compatibility.html#singularity-command-symlink