### PR TITLE
Enable pre-commit hooks and fix associated code formatting problems

### DIFF
--- a/.github/workflows/test-spras.yml
+++ b/.github/workflows/test-spras.yml
@@ -126,3 +126,17 @@ jobs:
         tags: latest
         cache_froms: reedcompbio/mincostflow:latest
         push: false
+
+  # Run pre-commit checks on source files
+  pre-commit:
+    name: Run pre-commit checks
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8' # Match this to the version specified in environment.yml
+    - name: Run pre-commit checks
+      uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+# See https://pre-commit.com/ for documentation
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0  # Use the ref you want to point at
+    hooks:
+      # Attempts to load all yaml files to verify syntax.
+      - id: check-yaml
+      # Trims trailing whitespace. Preserves Markdown hard linebreaks.
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,11 @@ repos:
     hooks:
       # Attempts to load all yaml files to verify syntax.
       - id: check-yaml
-      # Trims trailing whitespace. Preserves Markdown hard linebreaks.
+      # Trims trailing whitespace.
       - id: trailing-whitespace
+        # Preserves Markdown hard linebreaks.
         args: [--markdown-linebreak-ext=md]
+        # Do not trim whitespace from all files, input files may need trailing whitespace for empty values in columns.
+        types_or: [markdown, python]
+        # Skip this Markdown file, which has an example of an input text file within it.
+        exclude: input/README.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,8 @@ repos:
     hooks:
       # Attempts to load all yaml files to verify syntax.
       - id: check-yaml
+      # Attempts to load all TOML files to verify syntax.
+      - id: check-toml
       # Trims trailing whitespace.
       - id: trailing-whitespace
         # Preserves Markdown hard linebreaks.
@@ -18,3 +20,7 @@ repos:
         types_or: [markdown, python, yaml]
         # Skip this Markdown file, which has an example of an input text file within it.
         exclude: input/README.md
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.269'
+    hooks:
+      - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 # See https://pre-commit.com/ for documentation
+default_language_version:
+  # Match this to the version specified in environment.yml
+  python: python3.8
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0  # Use the ref you want to point at

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,6 @@ repos:
         # Preserves Markdown hard linebreaks.
         args: [--markdown-linebreak-ext=md]
         # Do not trim whitespace from all files, input files may need trailing whitespace for empty values in columns.
-        types_or: [markdown, python]
+        types_or: [markdown, python, yaml]
         # Skip this Markdown file, which has an example of an input text file within it.
         exclude: input/README.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,3 +135,20 @@ The pull request will be closed so that future contributors can practice with th
 1. Add example usage for the new algorithm and its parameters to the template config file
 1. Write test functions and provide example input data in a new test subdirectory `test/<algorithm>`
 1. Extend `.github/workflows/test-spras.yml` to pull and build the new Docker image
+
+## Pre-commit hooks
+SPRAS uses [pre-commit hooks](https://github.com/pre-commit/pre-commit-hooks) to automatically catch certain types of formatting and programming errors in source files.
+Example errors include a yaml file that cannot be parsed or a local variable that is referenced before assignment.
+These tests are run automatically on every commit through the GitHub Actions.
+However, developers will benefit from setting up their environment to run the same tests locally while they modify the SPRAS source.
+
+The `pre-commit` package is installed as part of the conda environment in `environment.yml`.
+From there, the pre-commit [quick start](https://pre-commit.com/#quick-start) guide explains two primary ways to use it locally:
+- run against all source files with `pre-commit run --all-files` to identify errors and automatically fix them when possible
+- configure `git` to run the hooks before every `git commit` so that a commit will only succeed if the tests pass, ensuring new errors are not introduced
+
+Currently, SPRAS only enforces a small number of Python formatting conventions and runs a small number of tests.
+Additional hooks are [available](https://github.com/pre-commit/pre-commit-hooks#hooks-available).
+These are configured in `.pre-commit-config.yaml`.
+SPRAS also runs [`ruff`](https://github.com/charliermarsh/ruff) as part of the pre-commit hooks to perform the Python code analysis, which supports many more [rules](https://beta.ruff.rs/docs/rules/).
+These are configured in `pyproject.toml`.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,7 +25,7 @@
  # then myAlg will be run on (a=1,b=0.5),(a=1,b=0.75),(a=2,b=0.5), and (a=2,b=0,75). Pretty neat, but be
  # careful: too many parameters might make your runs take a long time.
 
- algorithms:
+ algorithms
         - name: "pathlinker"
           params:
                 include: true

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,7 +25,7 @@
  # then myAlg will be run on (a=1,b=0.5),(a=1,b=0.75),(a=2,b=0.5), and (a=2,b=0,75). Pretty neat, but be
  # careful: too many parameters might make your runs take a long time.
 
- algorithms
+ algorithms:
         - name: "pathlinker"
           params:
                 include: true

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -62,7 +62,7 @@
                     max_path_length: [3]
                     local_search: ["Yes"]
                     rand_restarts: [10]
-      
+
         - name: "mincostflow"
           params:
                 include: true
@@ -70,7 +70,7 @@
                 run1:
                     flow: [1] # The flow must be an int
                     capacity: [1]
-                    
+
 
  # Here we specify which pathways to run and other file location information.
  # DataLoader.py can currently only load a single dataset

--- a/config/egfr.yaml
+++ b/config/egfr.yaml
@@ -5,78 +5,78 @@ hash_length: 7
 # Singularity support is only available on Unix
 singularity: false
 
-algorithms: 
-  - 
+algorithms:
+  -
     name: pathlinker
-    params: 
+    params:
       directed: true
       include: true
-      run1: 
-        k: 
+      run1:
+        k:
           - 10
           - 20
-  - 
+  -
     name: omicsintegrator1
-    params: 
+    params:
       directed: false
       include: true
-      run1: 
-        b: 
+      run1:
+        b:
           - 0.55
           - 2
           - 10
-        d: 
+        d:
           - 10
-        g: 
+        g:
           - 1e-3
-        r: 
+        r:
           - 0.01
-        w: 
+        w:
           - 0.1
         mu:
           - 0.008
-  - 
+  -
     name: omicsintegrator2
-    params: 
+    params:
       directed: false
       include: false
-      run1: 
-        b: 
+      run1:
+        b:
           - 4
-        g: 
+        g:
           - 0
-      run2: 
-        b: 
+      run2:
+        b:
           - 2
-        g: 
+        g:
           - 3
-  - 
+  -
     name: meo
-    params: 
+    params:
       directed: true
       include: false
-      run1: 
-        local_search: 
+      run1:
+        local_search:
           - "Yes"
-        max_path_length: 
+        max_path_length:
           - 3
-        rand_restarts: 
+        rand_restarts:
           - 10
-datasets: 
-  - 
+datasets:
+  -
     data_dir: input
-    edge_files: 
+    edge_files:
       - phosphosite-irefindex13.0-uniprot.txt
     label: tps-egfr
-    node_files: 
+    node_files:
       - tps-egfr-prizes.txt
     other_files: []
-reconstruction_settings: 
-  locations: 
+reconstruction_settings:
+  locations:
     reconstruction_dir: output/egfr
   run: true
-analysis: 
-  graphspace: 
+analysis:
+  graphspace:
     include: false
-  summary: 
+  summary:
     include: true

--- a/docker-wrappers/LocalNeighborhood/README.md
+++ b/docker-wrappers/LocalNeighborhood/README.md
@@ -9,7 +9,7 @@ New contributors complete the `Dockerfile` to wrap the implementation in `local_
 ## Usage
 ```
 $ python local_neighborhood.py -h
-usage: local_neighborhood.py [-h] --network NETWORK --nodes NODES --output OUTPUT        
+usage: local_neighborhood.py [-h] --network NETWORK --nodes NODES --output OUTPUT  
 
 Local neighborhood pathway reconstruction
 

--- a/docker-wrappers/MinCostFlow/README.md
+++ b/docker-wrappers/MinCostFlow/README.md
@@ -29,7 +29,7 @@ The expected output graphs for different flow and capacity values are in the `ex
 The Docker wrapper can be tested with `pytest -k test_mcf.py` from the root of the SPRAS repository.
 
 Alternatively, to run the Docker image directly, run the following command from the root of the `spras` repository
-``` 
+```
 docker run -w /data --mount type=bind,source=/${PWD},target=/data reedcompbio/mincostflow python /MinCostFlow/minCostFlow.py --edges_file /data/test/MinCostFlow/input/graph1/edges.txt --sources_file /data/test/MinCostFlowinput/graph1/sources.txt --targets_file /data/test/MinCostFlowinput/graph1/targets.txt --flow 1 --output graph1 --capacity 1  
 ```
 

--- a/environment.yml
+++ b/environment.yml
@@ -7,8 +7,8 @@ dependencies:
   - matplotlib=3.5
   - networkx=2.8
   - pandas=1.4
-  - pre-commit=2.20
-  - pytest=7.1
+  - pre-commit=2.20 # Only required for development
+  - pytest=7.1 # Only required for development
   - python=3.8
   - pip=22.1
   - requests=2.28

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - matplotlib=3.5
   - networkx=2.8
   - pandas=1.4
+  - pre-commit=2.20
   - pytest=7.1
   - python=3.8
   - pip=22.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ fix = true
 # Select categories or specific rules from https://beta.ruff.rs/docs/rules/
 select = [
     "B", # flake8-bugbear
+    "D300", # docstring triple-single-quotes
     "E101", # mixed-spaces-and-tabs
     "E711", # none-comparison
     "E713", # not-in-test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.ruff]
+target-version = "py38"
+# Autofix errors when possible
+fix = true
+# Select categories or specific rules from https://beta.ruff.rs/docs/rules/
+select = [
+    "B", # flake8-bugbear
+    "E101", # mixed-spaces-and-tabs
+    "E711", # none-comparison
+    "E713", # not-in-test
+    "E714" , # not-is-test
+    "F821", # undefined-name
+    "F823", # undefined-local
+    "F841", # unused-variable
+    "I", # isort
+    "W292", # missing-newline-at-end-of-file
+]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,6 @@
-from os.path import dirname, basename, isfile, join
 import glob
+from os.path import basename, dirname, isfile, join
+
 modules = glob.glob(join(dirname(__file__), "*.py"))
 
 __all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]

--- a/src/analysis/graphspace.py
+++ b/src/analysis/graphspace.py
@@ -1,9 +1,11 @@
-from graphspace_python.api.client import GraphSpace
-from graphspace_python.graphs.classes.gsgraph import GSGraph
-import networkx as nx
+import json
 import os
 import sys
-import json
+
+import networkx as nx
+from graphspace_python.api.client import GraphSpace
+from graphspace_python.graphs.classes.gsgraph import GSGraph
+
 
 def write_json(graph_file,out_graph,out_style,directed=False) -> None:
 
@@ -28,9 +30,9 @@ files before we post to GraphSpace.
 def post_graph(G:GSGraph,username:str,password:str,directed=False) -> None:
 	gs = GraphSpace(username,password)
 	try:
-		graph = gs.update_graph(G)
+		gs.update_graph(G)
 	except:
-		graph = gs.post_graph(G)
+		gs.post_graph(G)
 	print('posted graph')
 	return
 

--- a/src/analysis/summary.py
+++ b/src/analysis/summary.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 def summarize_networks(file_paths: Iterable[Path], node_table: pd.DataFrame) -> pd.DataFrame:
     """
-    Generate a table that aggregates summary information about networks in file_paths, 
+    Generate a table that aggregates summary information about networks in file_paths,
     including which nodes are present in node_table columns.
     @param file_paths: iterable of edge list files
     @param node_table: pandas DataFrame containing node attributes

--- a/src/analysis/summary.py
+++ b/src/analysis/summary.py
@@ -1,9 +1,10 @@
-import sys
-import networkx as nx
 import os
-import pandas as pd
-from typing import Iterable
+import sys
 from pathlib import Path
+from typing import Iterable
+
+import networkx as nx
+import pandas as pd
 
 
 def summarize_networks(file_paths: Iterable[Path], node_table: pd.DataFrame) -> pd.DataFrame:

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -27,23 +27,23 @@ class Dataset:
         return
 
     def to_file(self, file_name):
-        '''
+        """
         Saves dataset object to pickle file
-        '''
+        """
         with open(file_name, "wb") as f:
             pkl.dump(self, f)
 
     @classmethod
     def from_file(cls, file_name):
-        '''
+        """
         Loads dataset object from a pickle file.
         Usage: dataset = Dataset.from_file(pickle_file)
-        '''
+        """
         with open(file_name, "rb") as f:
             return pkl.load(f)
 
     def load_files_from_dict(self, dataset_dict):
-        '''
+        """
         Loads data files from dataset_dict, which is one dataset dictionary from the list
         in the config file with the fields in the config file.
         Populates node_table, edge_table, and interactome.
@@ -59,7 +59,7 @@ class Dataset:
         be handled outside this class.
 
         returns: none
-        '''
+        """
 
         self.label = dataset_dict["label"]
 
@@ -97,10 +97,10 @@ class Dataset:
         self.other_files = dataset_dict["other_files"]
 
     def request_node_columns(self, col_names):
-        '''
+        """
         returns: A table containing the requested column names and node IDs
         for all nodes with at least 1 of the requested values being non-empty
-        '''
+        """
         col_names.append(self.NODE_ID)
         filtered_table = self.node_table[col_names]
         filtered_table = filtered_table.dropna(axis=0, how='all',subset=filtered_table.columns.difference([self.NODE_ID]))
@@ -111,10 +111,10 @@ class Dataset:
         return filtered_table
 
     def contains_node_columns(self, col_names):
-        '''
+        """
         col_names: A list-like object of column names to check or a string of a single column name to check.
         returns: Whether or not all columns in col_names exist in the dataset.
-        '''
+        """
         if isinstance(col_names, str):
             return col_names in self.node_table.columns
         else:

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -1,7 +1,8 @@
-import pandas as pd
-import warnings
 import os
 import pickle as pkl
+import warnings
+
+import pandas as pd
 
 """
 Author: Chris Magnano
@@ -66,7 +67,7 @@ class Dataset:
         # TODO support multiple edge files
         interactome_loc = dataset_dict["edge_files"][0]
         node_data_files = dataset_dict["node_files"]
-        edge_data_files = [""] #Currently None
+        #edge_data_files = [""]  # Currently None
         data_loc = dataset_dict["data_dir"]
 
         #Load everything as pandas tables
@@ -105,7 +106,8 @@ class Dataset:
         filtered_table = filtered_table.dropna(axis=0, how='all',subset=filtered_table.columns.difference([self.NODE_ID]))
         percent_hit = (float(len(filtered_table))/len(self.node_table))*100
         if percent_hit <= self.warning_threshold*100:
-            warnings.warn("Only %0.2f of data had one or more of the following columns filled:"%(percent_hit) + str(col_names))
+            # Only use stacklevel 1 because this is due to the data not the code context
+            warnings.warn("Only %0.2f of data had one or more of the following columns filled:"%(percent_hit) + str(col_names), stacklevel=1)
         return filtered_table
 
     def contains_node_columns(self, col_names):

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -27,9 +27,9 @@ class Dataset:
         return
 
     def to_file(self, file_name):
-        """
+        '''
         Saves dataset object to pickle file
-        """
+        '''
         with open(file_name, "wb") as f:
             pkl.dump(self, f)
 
@@ -69,11 +69,13 @@ class Dataset:
         node_data_files = dataset_dict["node_files"]
         #edge_data_files = [""]  # Currently None
         data_loc = dataset_dict["data_dir"]
+        unused_var = None
 
         #Load everything as pandas tables
         self.interactome = pd.read_table(os.path.join(data_loc,interactome_loc), names = ["Interactor1","Interactor2","Weight"])
         node_set = set(self.interactome.Interactor1.unique())
         node_set = node_set.union(set(self.interactome.Interactor2.unique()))
+        print(undefined_var)
 
         #Load generic node tables
         self.node_table = pd.DataFrame(node_set, columns=[self.NODE_ID])

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -27,9 +27,9 @@ class Dataset:
         return
 
     def to_file(self, file_name):
-        '''
+        """
         Saves dataset object to pickle file
-        '''
+        """
         with open(file_name, "wb") as f:
             pkl.dump(self, f)
 
@@ -69,13 +69,11 @@ class Dataset:
         node_data_files = dataset_dict["node_files"]
         #edge_data_files = [""]  # Currently None
         data_loc = dataset_dict["data_dir"]
-        unused_var = None
 
         #Load everything as pandas tables
         self.interactome = pd.read_table(os.path.join(data_loc,interactome_loc), names = ["Interactor1","Interactor2","Weight"])
         node_set = set(self.interactome.Interactor1.unique())
         node_set = node_set.union(set(self.interactome.Interactor2.unique()))
-        print(undefined_var)
 
         #Load generic node tables
         self.node_table = pd.DataFrame(node_set, columns=[self.NODE_ID])

--- a/src/meo.py
+++ b/src/meo.py
@@ -1,7 +1,9 @@
-from src.prm import PRM
 from pathlib import Path
-from src.util import prepare_volume, run_container
+
 import pandas as pd
+
+from src.prm import PRM
+from src.util import prepare_volume, run_container
 
 __all__ = ['MEO', 'write_properties']
 

--- a/src/mincostflow.py
+++ b/src/mincostflow.py
@@ -1,7 +1,9 @@
-from src.prm import PRM
 from pathlib import Path
-from src.util import prepare_volume, run_container
+
 import pandas as pd
+
+from src.prm import PRM
+from src.util import prepare_volume, run_container
 
 __all__ = ['MinCostFlow']
 

--- a/src/mincostflow.py
+++ b/src/mincostflow.py
@@ -16,25 +16,25 @@ class MinCostFlow (PRM):
         @param data: dataset
         @param filename_map: a dict mapping file types in the required_inputs to the filename for that type
         """
-        
-        # ensures the required input are within the filename_map 
+
+        # ensures the required input are within the filename_map
         for input_type in MinCostFlow.required_inputs:
             if input_type not in filename_map:
                 raise ValueError(f"{input_type} filename is missing")
 
-        # will take the sources and write them to files, and repeats with targets 
+        # will take the sources and write them to files, and repeats with targets
         for node_type in ['sources', 'targets']:
             nodes = data.request_node_columns([node_type])
             if nodes is None:
                 raise ValueError(f'No {node_type} found in the node files')
             # take nodes one column data frame, call sources/ target series
             nodes = nodes.loc[nodes[node_type]]
-            # creates with the node type without headers 
+            # creates with the node type without headers
             nodes.to_csv(filename_map[node_type], index=False, columns=['NODEID'], header=False)
 
-        # create the network of edges 
+        # create the network of edges
         edges = data.get_interactome()
-        
+
         # creates the edges files that contains the head and tail nodes and the weights after them
         edges.to_csv(filename_map['edges'], sep='\t', index=False, columns=["Interactor1","Interactor2","Weight"], header=False)
 
@@ -58,9 +58,9 @@ class MinCostFlow (PRM):
         # the data files will be mapped within this directory within the container
         work_dir = '/mincostflow'
 
-        # the tuple is for mapping the sources, targets, edges, and output 
+        # the tuple is for mapping the sources, targets, edges, and output
         volumes = list()
- 
+
         bind_path, sources_file = prepare_volume(sources, work_dir)
         volumes.append(bind_path)
 
@@ -76,7 +76,7 @@ class MinCostFlow (PRM):
         bind_path, mapped_out_dir = prepare_volume(str(out_dir), work_dir)
         volumes.append(bind_path)
         mapped_out_prefix = mapped_out_dir + '/out'
-       
+
         # Makes the Python command to run within in the container
         command = ['python',
                     '/MinCostFlow/minCostFlow.py',
@@ -84,7 +84,7 @@ class MinCostFlow (PRM):
                     '--targets_file', targets_file,
                     '--edges_file', edges_file,
                     '--output', mapped_out_prefix]
-        
+
         # Optional arguments (extend the command if available)
         if flow is not None:
             command.extend(['--flow', str(flow)])
@@ -94,14 +94,14 @@ class MinCostFlow (PRM):
         # choosing to run in docker or singularity container
         container_framework = 'singularity' if singularity else 'docker'
 
-        # constructs a docker run call 
+        # constructs a docker run call
         out = run_container(container_framework,
                             'reedcompbio/mincostflow',
-                            command, 
+                            command,
                             volumes,
                             work_dir)
         print(out)
-  
+
         # Check the output of the container
         out_dir_content = sorted(out_dir.glob('*.sif'))
         # Expected behavior is that one output network is created
@@ -109,10 +109,10 @@ class MinCostFlow (PRM):
             output_edges = out_dir_content[0]
             output_edges.rename(output_file)
         # Never expect to reach this case
-        elif len(out_dir_content) > 1: 
+        elif len(out_dir_content) > 1:
             raise RuntimeError('MinCostFlow produced multiple output networks')
         # This case occurs if there are errors such as too much flow
-        else: 
+        else:
             raise RuntimeError('MinCostFlow did not produce an output network')
 
     @staticmethod
@@ -122,7 +122,7 @@ class MinCostFlow (PRM):
         @param raw_pathway_file: pathway file produced by an algorithm's run function
         @param standardized_pathway_file: the same pathway written in the universal format
         """
-        
+
         df = pd.read_csv(raw_pathway_file, sep='\t', header=None)
         df.insert(2, 'Rank', 1)  # adds in a rank column of 1s because the edges are not ranked
         df.to_csv(standardized_pathway_file, header=False, index=False, sep='\t')

--- a/src/omicsintegrator1.py
+++ b/src/omicsintegrator1.py
@@ -1,7 +1,9 @@
-from src.prm import PRM
 from pathlib import Path
-from src.util import prepare_volume, run_container
+
 import pandas as pd
+
+from src.prm import PRM
+from src.util import prepare_volume, run_container
 
 __all__ = ['OmicsIntegrator1', 'write_conf']
 
@@ -177,7 +179,7 @@ class OmicsIntegrator1(PRM):
         try:
             df = pd.read_csv(raw_pathway_file, sep='\t', header=None)
         except pd.errors.EmptyDataError:
-            with open(standardized_pathway_file, 'w') as emptyFile:
+            with open(standardized_pathway_file, 'w'):
                 pass
             return
         df = df.take([0, 2], axis=1)

--- a/src/omicsintegrator2.py
+++ b/src/omicsintegrator2.py
@@ -1,9 +1,11 @@
-from src.prm import PRM
-import docker
-from pathlib import Path
-from src.util import prepare_path_docker
 import os
+from pathlib import Path
+
+import docker
 import pandas as pd
+
+from src.prm import PRM
+from src.util import prepare_path_docker
 
 __all__ = ['OmicsIntegrator2']
 
@@ -117,7 +119,7 @@ class OmicsIntegrator2(PRM):
                 #This command changes the ownership of output files so we don't
                 # get a permissions error when snakemake tries to touch the files
                 chown_command = " ".join(["chown",str(uid),out_dir.as_posix()+"/oi2*"])
-                out_chown = client.containers.run('reedcompbio/omics-integrator-2',
+                client.containers.run('reedcompbio/omics-integrator-2',
                                             chown_command,
                                             stderr=True,
                                             volumes={prepare_path_docker(work_dir): {'bind': '/OmicsIntegrator2', 'mode': 'rw'}},
@@ -149,7 +151,7 @@ class OmicsIntegrator2(PRM):
         # Omicsintegrator2 returns a single line file if no network is found
         num_lines = sum(1 for line in open(raw_pathway_file))
         if num_lines < 2:
-            with open(standardized_pathway_file, 'w') as emptyFile:
+            with open(standardized_pathway_file, 'w'):
                 pass
             return
         df = pd.read_csv(raw_pathway_file, sep='\t')

--- a/src/pathlinker.py
+++ b/src/pathlinker.py
@@ -1,7 +1,9 @@
-import pandas as pd
 import warnings
-from src.prm import PRM
 from pathlib import Path
+
+import pandas as pd
+
+from src.prm import PRM
 from src.util import prepare_volume, run_container
 
 __all__ = ['PathLinker']
@@ -26,9 +28,10 @@ class PathLinker(PRM):
         if sources_targets is None:
             return False
         both_series = sources_targets.sources & sources_targets.targets
-        for index,row in sources_targets[both_series].iterrows():
+        for _index,row in sources_targets[both_series].iterrows():
             warn_msg = row.NODEID+" has been labeled as both a source and a target."
-            warnings.warn(warn_msg)
+            # Only use stacklevel 1 because this is due to the data not the code context
+            warnings.warn(warn_msg, stacklevel=1)
 
         #Create nodetype file
         input_df = sources_targets[["NODEID"]].copy()

--- a/src/runner.py
+++ b/src/runner.py
@@ -2,10 +2,10 @@ from src.dataset import Dataset
 
 # supported algorithm imports
 from src.meo import MEO as meo
+from src.mincostflow import MinCostFlow as mincostflow
 from src.omicsintegrator1 import OmicsIntegrator1 as omicsintegrator1
 from src.omicsintegrator2 import OmicsIntegrator2 as omicsintegrator2
 from src.pathlinker import PathLinker as pathlinker
-from src.mincostflow import MinCostFlow as mincostflow
 
 
 def run(algorithm, params):
@@ -14,8 +14,8 @@ def run(algorithm, params):
     """
     try:
         algorithm_runner = globals()[algorithm.lower()]
-    except KeyError:
-        raise NotImplementedError(f'{algorithm} is not currently supported')
+    except KeyError as exc:
+        raise NotImplementedError(f'{algorithm} is not currently supported') from exc
     algorithm_runner.run(**params)
 
 
@@ -27,8 +27,8 @@ def get_required_inputs(algorithm):
     """
     try:
         algorithm_runner = globals()[algorithm.lower()]
-    except KeyError:
-        raise NotImplementedError(f'{algorithm} is not currently supported')
+    except KeyError as exc:
+        raise NotImplementedError(f'{algorithm} is not currently supported') from exc
     return algorithm_runner.required_inputs
 
 
@@ -53,8 +53,8 @@ def prepare_inputs(algorithm, data_file, filename_map):
     dataset = Dataset.from_file(data_file)
     try:
         algorithm_runner = globals()[algorithm.lower()]
-    except KeyError:
-        raise NotImplementedError(f'{algorithm} is not currently supported')
+    except KeyError as exc:
+        raise NotImplementedError(f'{algorithm} is not currently supported') from exc
     return algorithm_runner.generate_inputs(dataset, filename_map)
 
 
@@ -67,6 +67,6 @@ def parse_output(algorithm, raw_pathway_file, standardized_pathway_file):
     """
     try:
         algorithm_runner = globals()[algorithm.lower()]
-    except KeyError:
-        raise NotImplementedError(f'{algorithm} is not currently supported')
+    except KeyError as exc:
+        raise NotImplementedError(f'{algorithm} is not currently supported') from exc
     return algorithm_runner.parse_output(raw_pathway_file, standardized_pathway_file)

--- a/src/util.py
+++ b/src/util.py
@@ -149,7 +149,7 @@ def run_container_docker(container: str, command: List[str], volumes: List[Tuple
                                     volumes=bind_paths,
                                     working_dir=working_dir,
                                     environment=[environment]).decode('utf-8')
-            
+
         # Raised on non-Unix systems
         except AttributeError:
             pass

--- a/src/util.py
+++ b/src/util.py
@@ -3,16 +3,17 @@ Utility functions for pathway reconstruction
 """
 
 import base64
-import docker
-import itertools as it
 import hashlib
+import itertools as it
 import json
-import re
 import os
 import platform
-import numpy as np  # Required to eval some forms of parameter ranges
-from typing import Dict, Any, Optional, Union, Tuple, List
+import re
 from pathlib import Path, PurePath, PurePosixPath
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import docker
+import numpy as np  # Required to eval some forms of parameter ranges
 
 # The default length of the truncated hash used to identify parameter combinations
 DEFAULT_HASH_LENGTH = 7
@@ -153,13 +154,16 @@ def run_container_docker(container: str, command: List[str], volumes: List[Tuple
         # Raised on non-Unix systems
         except AttributeError:
             pass
-        return out
+
+        # TODO: Not sure whether this is needed or where to close the client
+        client.close()
+
     except Exception as err:
         print(err)
-    finally:
-        # Not sure whether this is needed
-        client.close()
-        return out
+    # Removed the finally block to address bugbear B012
+    # "`return` inside `finally` blocks cause exceptions to be silenced"
+    # finally:
+    return out
 
 
 def run_container_singularity(container: str, command: List[str], volumes: List[Tuple[PurePath, PurePath]], working_dir: str, environment: str = 'SPRAS=True'):
@@ -289,7 +293,7 @@ def process_config(config):
     # Override the default parameter hash length if specified in the config file
     try:
         hash_length = int(config["hash_length"])
-    except (ValueError, KeyError) as e:
+    except (ValueError, KeyError):
         hash_length = DEFAULT_HASH_LENGTH
     prior_params_hashes = set()
 

--- a/test/LocalNeighborhood/test_ln.py
+++ b/test/LocalNeighborhood/test_ln.py
@@ -1,7 +1,10 @@
-import pytest
 import sys
 from pathlib import Path
+
+import pytest
+
 from src.util import compare_files
+
 # TODO consider refactoring to simplify the import
 # Modify the path because of the - in the directory
 SPRAS_ROOT = Path(__file__).parent.parent.parent.absolute()

--- a/test/MEO/test_meo.py
+++ b/test/MEO/test_meo.py
@@ -1,6 +1,8 @@
-import pytest
 import shutil
 from pathlib import Path
+
+import pytest
+
 from src.meo import MEO, write_properties
 
 TEST_DIR = 'test/MEO/'

--- a/test/MinCostFlow/test_mcf.py
+++ b/test/MinCostFlow/test_mcf.py
@@ -1,6 +1,8 @@
-import pytest
 import shutil
 from pathlib import Path
+
+import pytest
+
 from src.mincostflow import MinCostFlow
 
 TEST_DIR = 'test/MinCostFlow/'

--- a/test/OmicsIntegrator1/test_oi1.py
+++ b/test/OmicsIntegrator1/test_oi1.py
@@ -1,6 +1,8 @@
-import pytest
 import shutil
 from pathlib import Path
+
+import pytest
+
 from src.omicsintegrator1 import OmicsIntegrator1, write_conf
 
 TEST_DIR = 'test/OmicsIntegrator1/'

--- a/test/OmicsIntegrator2/test_oi2.py
+++ b/test/OmicsIntegrator2/test_oi2.py
@@ -1,4 +1,5 @@
 import pytest
+
 from src.omicsintegrator2 import OmicsIntegrator2
 
 TEST_DIR = 'test/OmicsIntegrator2/'

--- a/test/PathLinker/test_pathlinker.py
+++ b/test/PathLinker/test_pathlinker.py
@@ -1,6 +1,8 @@
-import pytest
 import shutil
 from pathlib import Path
+
+import pytest
+
 from src.pathlinker import PathLinker
 
 TEST_DIR = 'test/PathLinker/'

--- a/test/analysis/test_analysis.py
+++ b/test/analysis/test_analysis.py
@@ -1,5 +1,5 @@
-import src.analysis.summary as summary
 import src.analysis.graphspace as graphspace
+import src.analysis.summary as summary
 
 TEST_DIR = 'test/analysis/'
 

--- a/test/analysis/test_summary.py
+++ b/test/analysis/test_summary.py
@@ -1,6 +1,8 @@
-import pandas as pd
-from src.analysis.summary import summarize_networks
 from pathlib import Path
+
+import pandas as pd
+
+from src.analysis.summary import summarize_networks
 
 # Notes:
 # - Column labels are required in the node table

--- a/test/ml/test_ml.py
+++ b/test/ml/test_ml.py
@@ -2,6 +2,7 @@ import filecmp
 from pathlib import Path
 
 import pandas as pd
+
 import src.analysis.ml as ml
 
 INPUT_DIR = 'test/ml/input/'

--- a/test/test_prepare_inputs.py
+++ b/test/test_prepare_inputs.py
@@ -1,7 +1,9 @@
-from src import runner
-import shutil
-import yaml
 import os
+import shutil
+
+import yaml
+
+from src import runner
 
 config_loc = os.path.join("config", "config.yaml")
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,6 +1,13 @@
-import pytest
 from pathlib import PurePosixPath, PureWindowsPath
-from src.util import convert_docker_path, prepare_path_docker, prepare_volume, hash_params_sha1_base32
+
+import pytest
+
+from src.util import (
+    convert_docker_path,
+    hash_params_sha1_base32,
+    prepare_path_docker,
+    prepare_volume,
+)
 
 
 class TestUtil:


### PR DESCRIPTION
This pull requests implements pre-commit hooks as described in #53. However, I would like to leave #53 open because there are many more formatting rules and external tools we may decide to add over time. For instance, [black](https://github.com/psf/black) is a popular Python code formatter and there are many more [rules](https://beta.ruff.rs/docs/rules/) that ruff supports and [hooks](https://github.com/pre-commit/pre-commit-hooks#hooks-available) available.

The new section of the contributing guide explains how the pre-commit checks work and how developers would use them. It take some adjustment because `git commit` will fail and the commit with _not_ be made if formatting errors are encountered in the files that are in the scope of the commit.

I'll follow up with a commit or two that introduce formatting errors so we can observe the new GitHub Actions test failing.