### PR TITLE
Add bash to PathLinker image

### DIFF
--- a/.github/workflows/test-spras.yml
+++ b/.github/workflows/test-spras.yml
@@ -81,7 +81,7 @@ jobs:
         docker pull reedcompbio/pathlinker:v2
         docker pull reedcompbio/meo:latest
         docker pull reedcompbio/mincostflow:latest
-        docker pull reedcompbio/allpairs:latest
+        docker pull reedcompbio/allpairs:v2
         docker pull reedcompbio/domino:latest
         docker pull reedcompbio/py4cytoscape:v2
     - name: Build Omics Integrator 1 Docker image
@@ -135,7 +135,7 @@ jobs:
         path: docker-wrappers/AllPairs/.
         dockerfile: docker-wrappers/AllPairs/Dockerfile
         repository: reedcompbio/allpairs
-        tags: latest
+        tags: v2
         cache_froms: reedcompbio/allpairs:latest
         push: false
     - name: Build DOMINO Docker image

--- a/.github/workflows/test-spras.yml
+++ b/.github/workflows/test-spras.yml
@@ -78,11 +78,12 @@ jobs:
       run: |
         docker pull reedcompbio/omics-integrator-1:latest
         docker pull reedcompbio/omics-integrator-2:v2
-        docker pull reedcompbio/pathlinker:latest
+        docker pull reedcompbio/pathlinker:v2
         docker pull reedcompbio/meo:latest
         docker pull reedcompbio/mincostflow:latest
         docker pull reedcompbio/allpairs:latest
         docker pull reedcompbio/domino:latest
+        docker pull reedcompbio/py4cytoscape:v2
     - name: Build Omics Integrator 1 Docker image
       uses: docker/build-push-action@v1
       with:
@@ -108,7 +109,7 @@ jobs:
         dockerfile: docker-wrappers/PathLinker/Dockerfile
         repository: reedcompbio/pathlinker
         tags: latest
-        cache_froms: reedcompbio/pathlinker:latest
+        cache_froms: reedcompbio/pathlinker:v2
         push: false
     - name: Build Maximum Edge Orientation Docker image
       uses: docker/build-push-action@v1

--- a/.github/workflows/test-spras.yml
+++ b/.github/workflows/test-spras.yml
@@ -100,7 +100,7 @@ jobs:
         dockerfile: docker-wrappers/OmicsIntegrator2/Dockerfile
         repository: reedcompbio/omics-integrator-2
         tags: v2
-        cache_froms: reedcompbio/omics-integrator-2:v2
+        cache_froms: reedcompbio/omics-integrator-2:latest
         push: false
     - name: Build PathLinker Docker image
       uses: docker/build-push-action@v1
@@ -108,8 +108,8 @@ jobs:
         path: docker-wrappers/PathLinker/.
         dockerfile: docker-wrappers/PathLinker/Dockerfile
         repository: reedcompbio/pathlinker
-        tags: latest
-        cache_froms: reedcompbio/pathlinker:v2
+        tags: v2
+        cache_froms: reedcompbio/pathlinker:latest
         push: false
     - name: Build Maximum Edge Orientation Docker image
       uses: docker/build-push-action@v1
@@ -154,7 +154,7 @@ jobs:
         dockerfile: docker-wrappers/Cytoscape/Dockerfile
         repository: reedcompbio/py4cytoscape
         tags: v2
-        cache_froms: reedcompbio/py4cytoscape:v2
+        cache_froms: reedcompbio/py4cytoscape:latest
         push: false
 
   # Run pre-commit checks on source files

--- a/docker-wrappers/AllPairs/Dockerfile
+++ b/docker-wrappers/AllPairs/Dockerfile
@@ -1,6 +1,9 @@
 # AllPairs wrapper
 FROM python:3.9-alpine3.16
 
+# bash is required for dsub in the All of Us cloud environment
+RUN apk add --no-cache bash
+
 WORKDIR /AllPairs
 
 RUN pip install networkx==2.6.3

--- a/docker-wrappers/AllPairs/README.md
+++ b/docker-wrappers/AllPairs/README.md
@@ -26,3 +26,6 @@ The Docker wrapper can be tested with `pytest -k test_ap.py` from the root of th
 ## Notes
 - The `all-pairs-shortest-paths.py` code is located locally in SPRAS (since the code is short). It is under `docker-wrappers/AllPairs`.
 - Samples of an input network and source/target file are located under test/AllPairs/input.
+
+## Versions:
+- v1: Initial version. Copies source file from SPRAS repository.

--- a/docker-wrappers/AllPairs/README.md
+++ b/docker-wrappers/AllPairs/README.md
@@ -29,3 +29,4 @@ The Docker wrapper can be tested with `pytest -k test_ap.py` from the root of th
 
 ## Versions:
 - v1: Initial version. Copies source file from SPRAS repository.
+- v2: Add bash, which is not available in Alpine Linux.

--- a/docker-wrappers/PathLinker/Dockerfile
+++ b/docker-wrappers/PathLinker/Dockerfile
@@ -4,7 +4,8 @@ FROM python:3.5.10-alpine
 
 # gettext is required for the envsubst command
 # See https://github.com/haskell/cabal/issues/6126 regarding wget
-RUN apk add --no-cache ca-certificates gettext wget
+# bash is required for dsub in the All of Us cloud environment
+RUN apk add --no-cache ca-certificates gettext wget bash
 
 WORKDIR /PathLinker
 COPY pathlinker-files.txt .

--- a/docker-wrappers/PathLinker/README.md
+++ b/docker-wrappers/PathLinker/README.md
@@ -29,6 +29,7 @@ Windows users may need to escape the absolute paths so that `/data` becomes `//d
 
 ## Versions:
 - v1: Initial version. Copies PathLinker source files from GitHub and pip installs packages from requirements file.
+- v2: Add bash, which is not available in Alpine Linux.
 
 ## TODO
 - Attribute https://github.com/Murali-group/PathLinker

--- a/docker-wrappers/PathLinker/README.md
+++ b/docker-wrappers/PathLinker/README.md
@@ -27,6 +27,9 @@ docker run -w /data --mount type=bind,source=/${PWD},target=/data reedcompbio/pa
 This will run PathLinker on the test input files and write the output files to the root of the `spras` repository.
 Windows users may need to escape the absolute paths so that `/data` becomes `//data`, etc.
 
+## Versions:
+- v1: Initial version. Copies PathLinker source files from GitHub and pip installs packages from requirements file.
+
 ## TODO
 - Attribute https://github.com/Murali-group/PathLinker
 - Document usage

--- a/spras/allpairs.py
+++ b/spras/allpairs.py
@@ -94,8 +94,7 @@ class AllPairs(PRM):
 
         print('Running All Pairs Shortest Paths with arguments: {}'.format(' '.join(command)), flush=True)
 
-        container_suffix = "allpairs"
-
+        container_suffix = "allpairs:v2"
         out = run_container(
                             container_framework,
                             container_suffix,

--- a/spras/pathlinker.py
+++ b/spras/pathlinker.py
@@ -115,7 +115,7 @@ class PathLinker(PRM):
 
         print('Running PathLinker with arguments: {}'.format(' '.join(command)), flush=True)
 
-        container_suffix = "pathlinker"
+        container_suffix = "pathlinker:v2"
         out = run_container(container_framework,
                             container_suffix,
                             command,


### PR DESCRIPTION
This updates the PathLinker Docker image to include bash as described in https://github.com/Reed-CompBio/spras/issues/130#issuecomment-2182842994

Before making the change, I versioned the prior image as v1 and pushed it to DockerHub. This update is now v2.