### PR TITLE
Modify GHA Docker build tests to clean up after themselves

### DIFF
--- a/.github/workflows/test-spras.yml
+++ b/.github/workflows/test-spras.yml
@@ -94,6 +94,12 @@ jobs:
         tags: latest
         cache_froms: reedcompbio/omics-integrator-1:latest
         push: false
+    - name: Remove Omics Integrator 1 Docker image
+      # Remove the image to prevent the cache from being used. Here we use
+      # `|| true` to prevent the job from failing if the image doesn't exist or
+      # can't be removed for some reason
+      run: docker rmi reedcompbio/omics-integrator-1:latest || true
+
     - name: Build Omics Integrator 2 Docker image
       uses: docker/build-push-action@v1
       with:
@@ -103,6 +109,9 @@ jobs:
         tags: v2
         cache_froms: reedcompbio/omics-integrator-2:latest
         push: false
+    - name: Remove Omics Integrator 2 Docker image
+      run: docker rmi reedcompbio/omics-integrator-2:latest || true
+
     - name: Build PathLinker Docker image
       uses: docker/build-push-action@v1
       with:
@@ -112,6 +121,9 @@ jobs:
         tags: v2
         cache_froms: reedcompbio/pathlinker:latest
         push: false
+    - name: Remove PathLinker Docker image
+      run: docker rmi reedcompbio/pathlinker:latest || true
+
     - name: Build Maximum Edge Orientation Docker image
       uses: docker/build-push-action@v1
       with:
@@ -121,6 +133,9 @@ jobs:
         tags: latest
         cache_froms: reedcompbio/meo:latest
         push: false
+    - name: Remove MEO Docker image
+      run: docker rmi reedcompbio/meo:latest || true
+
     - name: Build MinCostFlow Docker image
       uses: docker/build-push-action@v1
       with:
@@ -130,6 +145,9 @@ jobs:
         tags: latest
         cache_froms: reedcompbio/mincostflow:latest
         push: false
+    - name: Remove MinCostFlow Docker image
+      run: docker rmi reedcompbio/mincostflow:latest || true
+
     - name: Build All Pairs Shortest Paths Docker image
       uses: docker/build-push-action@v1
       with:
@@ -139,6 +157,9 @@ jobs:
         tags: v2
         cache_froms: reedcompbio/allpairs:latest
         push: false
+    - name: Remove All Pairs Shortest Paths Docker image
+      run: docker rmi reedcompbio/allpairs:latest || true
+
     - name: Build DOMINO Docker image
       uses: docker/build-push-action@v1
       with:
@@ -148,6 +169,9 @@ jobs:
         tags: latest
         cache_froms: reedcompbio/domino:latest
         push: false
+    - name: Remove DOMINO Docker image
+      run: docker rmi reedcompbio/domino:latest || true
+
     - name: Build Cytoscape Docker image
       uses: docker/build-push-action@v1
       with:
@@ -157,6 +181,9 @@ jobs:
         tags: v3
         cache_froms: reedcompbio/py4cytoscape:v3
         push: false
+    - name: Remove Cytoscape Docker image
+      run: docker rmi reedcompbio/py4cytoscape:v3 || true
+
     - name: Build SPRAS Docker image
       uses: docker/build-push-action@v1
       with:
@@ -166,6 +193,8 @@ jobs:
         tags: v0.1.0
         cache_froms: reedcompbio/spras:v0.1.0
         push: false
+    - name: Remove SPRAS Docker image
+      run: docker rmi reedcompbio/spras:v0.1.0 || true
 
   # Run pre-commit checks on source files
   pre-commit:

--- a/docker-wrappers/SPRAS/Dockerfile
+++ b/docker-wrappers/SPRAS/Dockerfile
@@ -1,12 +1,11 @@
 FROM almalinux:9
 
-RUN dnf install -y epel-release
-
 # gcc/g++ are required for building several of the packages if you're using apple silicon
 RUN dnf update -y && \
-    dnf install -y gcc gcc-c++ \
+    dnf install -y epel-release gcc gcc-c++ \
     python3.11 python3.11-pip python3.11-devel \
-    docker apptainer
+    docker apptainer && \
+    dnf clean all
 
 COPY / /spras/
 RUN chmod -R 777 /spras

--- a/docker-wrappers/SPRAS/Dockerfile
+++ b/docker-wrappers/SPRAS/Dockerfile
@@ -2,7 +2,8 @@ FROM almalinux:9
 
 # gcc/g++ are required for building several of the packages if you're using apple silicon
 RUN dnf update -y && \
-    dnf install -y epel-release gcc gcc-c++ \
+    dnf install -y epel-release && \
+    dnf install -y gcc gcc-c++ \
     python3.11 python3.11-pip python3.11-devel \
     docker apptainer && \
     dnf clean all


### PR DESCRIPTION
@ntalluri reports several failing CI tests caused by insufficient disk space in the GHA runner's host OS, and it looks like the available disk is being chewed through by the docker build tests.

This PR adds an additional step to each container build test that explicitly deletes the image after it has been built. Hopefully this leads to more efficient use of space.