### PR TITLE
Enable long Snakemake workflows in HTCondor

### DIFF
--- a/docker-wrappers/SPRAS/README.md
+++ b/docker-wrappers/SPRAS/README.md
@@ -122,7 +122,7 @@ The second option is to let HTCondor manage the Snakemake process, which allows 
 ./snakemake_long.py --profile spras_profile --htcondor-jobdir <path/to/logging/directory>
 ```
 
-When run in this mode, all log files for the workflow will be placed into the path you provided for the logging directory. In particular, Snakemake's outputs with job progress can be found split between `<logdir>/snakemake-long.err` and `<logdir>/snakemake-long.out`.
+When run in this mode, all log files for the workflow will be placed into the path you provided for the logging directory. In particular, Snakemake's outputs with job progress can be found split between `<logdir>/snakemake-long.err` and `<logdir>/snakemake-long.out`. These will also log each rule and what HTCondor job ID was submitted for that rule (see the [troubleshooting section](#troubleshooting) for information on how to use these extra log files).
 
 ### Adjusting Resources
 
@@ -151,6 +151,13 @@ contain useful debugging clues about what may have gone wrong.
 **Note**: If you want to run the workflow with a different version of SPRAS, or one that contains development updates you've made, rebuild this image against
 the version of SPRAS you want to test, and push the image to your image repository. To use that container in the workflow, change the `container_image` line of
 `spras.sub` to point to the new image.
+
+### Troubleshooting
+Some errors Snakemake might encounter while executing rules in the workflow boil down to bad luck in a distributed, heterogeneous computational environment, and it's expected that some errors can be solved simply by rerunning. If you encounter a Snakemake error, try restarting the workflow to see if the same error is generated in the same rule a second time -- repeatable, identical failures are more likely to indicate a more fundamental issue that might require user intervention to fix.
+
+To investigate issues, start by referring to your logging directory. Each Snakemake rule submitted to HTCondor will log a corresponding HTCondor job ID in the Snakemake standard out/error. You can use this job ID to check the standard out, standard error, and HTCondor job log for that specific rule. In some cases the error will indicate a user-solvable issue, e.g. "input file not found" might point to a typo in some part of your workflow. In other cases, errors might be solved by retrying the workflow, which causes Snakemake to pick up where it left off.
+
+If your workflow gets stuck on the same error after multiple consecutive retries and prevents your workflow from completing, this indicates some user/developer intervention is likely required. If you choose to open a github issue, please include a description of the error(s) and what troubleshooting steps you've already taken.
 
 ## Versions:
 

--- a/docker-wrappers/SPRAS/example_config.yaml
+++ b/docker-wrappers/SPRAS/example_config.yaml
@@ -149,3 +149,5 @@ analysis:
         linkage: 'ward'
         # 'euclidean', 'manhattan', 'cosine'
         metric: 'euclidean'
+      evaluation:
+        include: false

--- a/docker-wrappers/SPRAS/snakemake_long.py
+++ b/docker-wrappers/SPRAS/snakemake_long.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+"""
+A wrapper script that allows long-term Snakemake workflows to run on HTCondor. This works
+by submitting a local universe job responsible for overseeing the terminal session that
+runs the actual snakemake executable.
+"""
+
+import argparse
+import os
+import pathlib
+import subprocess
+import sys
+import time
+
+import htcondor
+
+"""
+Parse various arguments for the script. Note that this script has two "modes" of operation which
+need different arguments. The "top" mode is for submitting the HTCondor wrapper, and the "long" mode
+is for running the Snakemake command itself.
+"""
+def parseArgs(isLocal=False):
+    parser = argparse.ArgumentParser(description="A tool for long-running Snakemake jobs with HTCondor.")
+    # We add a special command to trigger allowing this script to execute the long-running Snakemake command.
+    if isLocal:
+        parser.add_argument("command", help="Helper command to run", choices=["long"])
+    parser.add_argument("--snakefile", help="The Snakefile to run.", required=False)
+    parser.add_argument("--profile", help="A path to a directory containing the desired Snakemake profile.", required=True)
+    # I'd love to change this to "logdir", but using the same name as Snakemake for consistency of feeling between this script
+    # and Snakemake proper.
+    parser.add_argument("--htcondor-jobdir", help="The directory Snakemake will write logs to.", required=False)
+    return parser.parse_args()
+
+"""
+Given a Snakefile, profile, and HTCondor job directory, submit a local universe job that runs
+Snakemake from the context of the submission directory.
+"""
+def submitLocal(snakefile, profile, htcondor_jobdir):
+    # Get the location of this script, which also serves as the executable for the condor job.
+    script_location = pathlib.Path(__file__).resolve()
+
+    submit_description = htcondor.Submit({
+        "executable":              script_location,
+        "arguments":               f"long --snakefile {snakefile} --profile {profile} --htcondor-jobdir {htcondor_jobdir}",
+        "universe":                "local",
+        "request_disk":            "512MB",
+        "request_cpus":            1,
+        "request_memory":          512,
+
+        # Set up logging
+        "log":                     f"{htcondor_jobdir}/snakemake-long.log",
+        "output":                  f"{htcondor_jobdir}/snakemake-long.out",
+        "error":                   f"{htcondor_jobdir}/snakemake-long.err",
+
+        # Specify `getenv` so that our script uses the appropriate environment
+        # when it runs in local universe. This allows the job to access
+        # modules we've installed in the submission environment (notably spras).
+        "getenv":                  "true",
+
+        "JobBatchName":            f"spras-long-{time.strftime('%Y%m%d-%H%M%S')}",
+    })
+
+    schedd = htcondor.Schedd()
+    submit_result = schedd.submit(submit_description)
+
+    print("Snakemake management job was submitted with JobID %d.0. Logs can be found in %s" % (submit_result.cluster(), htcondor_jobdir))
+
+"""
+The top level function for the script that handles file creation/validation and triggers submission of the
+wrapper job.
+"""
+def topMain():
+    args = parseArgs()
+
+    # Check if the snakefile is provided. If not, assume it's in the current directory.
+    if args.snakefile is None:
+        cwd = os.getcwd()
+        args.snakefile = pathlib.Path(cwd) / "Snakefile"
+    if not os.path.exists(args.snakefile):
+        print(f"Error: The Snakefile {args.snakefile} does not exist.")
+        return 1
+
+    # Make sure the profile directory exists. It's harder to check if it's a valid profile at this level
+    # so that will be left to Snakemake.
+    if not os.path.exists(args.profile):
+        print(f"Error: The profile directory {args.profile} does not exist.")
+        return 1
+
+    # Make sure we have a value for the log directory and that the directory exists.
+    if args.htcondor_jobdir is None:
+        args.htcondor_jobdir = pathlib.Path(os.getcwd()) / "snakemake-long-logs"
+        if not os.path.exists(args.htcondor_jobdir):
+            os.makedirs(args.htcondor_jobdir)
+    else:
+        if not os.path.exists(args.htcondor_jobdir):
+            os.makedirs(args.htcondor_jobdir)
+
+
+    submitLocal(args.snakefile, args.profile, args.htcondor_jobdir)
+    return 0
+
+"""
+
+"""
+def longMain():
+    args = parseArgs(True)
+
+    # Command to activate conda environment and run Snakemake. Note that we need to unset APPTAINER_CACHEDIR
+    # in this case but not in the local terminal case because the wrapper HTCondor job has a different environment
+    # and populating this value causes Snakemake to fail when it tries to write to spool (a read-only filesystem from
+    # the perspective of the EP job).
+    command = f"""
+    source $(conda info --base)/etc/profile.d/conda.sh && \
+    conda activate spras && \
+    unset APPTAINER_CACHEDIR && \
+    snakemake -s {args.snakefile} --profile {args.profile} --htcondor-jobdir {args.htcondor_jobdir}
+    """
+
+    # Run the command in a single shell session
+    result = subprocess.run(command, shell=True, executable='/bin/bash')
+
+    # Return 0 for success and 1 for failure
+    return 0 if result.returncode == 0 else 1
+
+def main():
+    if len(sys.argv) > 1:
+        if sys.argv[1] in ["long"]:
+            return longMain()
+
+    return topMain()
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/docker-wrappers/SPRAS/spras_profile/config.yaml
+++ b/docker-wrappers/SPRAS/spras_profile/config.yaml
@@ -8,6 +8,10 @@ configfile: example_config.yaml
 # Indicate to the plugin that jobs running on various EPs do not share a filesystem with
 # each other, or with the AP.
 shared-fs-usage: none
+# Distributed, heterogeneous computational environments are a wild place where strange things
+# can happen. If something goes wrong, try again up to 5 times. After that, we assume there's
+# a real error that requires user/admin intervention
+retries: 5
 
 # Default resources will apply to all workflow steps. If a single workflow step fails due
 # to insufficient resources, it can be re-run with modified values. Snakemake will handle

--- a/docker-wrappers/SPRAS/spras_profile/config.yaml
+++ b/docker-wrappers/SPRAS/spras_profile/config.yaml
@@ -15,7 +15,8 @@ shared-fs-usage: none
 default-resources:
   job_wrapper: "spras.sh"
   # If running in CHTC, this only works with apptainer images
-  container_image: "spras.sif"
+  # Note requirement for quotes around the image name
+  container_image: "'spras-v0.2.0.sif'"
   universe: "container"
   # The value for request_disk should be large enough to accommodate the runtime container
   # image, any additional PRM container images, and your input data.


### PR DESCRIPTION
To avoid tying Snakemake execution to the current terminal (which is bad if
you ever want to log out of the AP or let your computer fall asleep), the new
script `snakemake_long.py` wraps Snakemake execution in an HTCondor local
universe job. This job is submitted like a regular HTCondor job, but it runs
on the AP in the context of the submit directory.
    
Usage:
`snakemake_long.py --snakefile (OPTIONAL) </path/to/snakefile> --profile (REQUIRED) </path/to/profile> --htcondor-jobdir (OPTIONAL) </path/to/logs>`

The only CLI option that might feel new here is `htcondor-jobdir`. This is
actually the same CLI used by the HTCondor executor, and it specifies a directory
in which logs are placed. I chose to keep names the same with this script so it
feels more familiar to Snakemake users.