### PR TITLE
Downgrade RTD python version to 3.11 to fix build error

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.11"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:


### PR DESCRIPTION
After reading through @agitter's notes in the linked issue, I agree that the issue appears to be that RTD is using python 3.12 here. A downgrade to 3.11 should do the trick for now.

Closes #211 