### PR TITLE
Fix Snakemake DAG.sanitize_local_storage_copies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - adjusttext=0.7.3.1
-  - bioconda::snakemake-minimal=8.16.0
+  - bioconda::snakemake-minimal=8.17.0
   - docker-py=5.0
   - matplotlib=3.6
   - networkx=2.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires-python = ">=3.11"
 dependencies = [
     "adjusttext==0.7.3",
     # A bug was introduced in older versions of snakemake that prevent it from running. Update to fix
-    "snakemake==8.16.0",
+    "snakemake==8.17.0",
     "docker==5.0.3", # Switched from docker-py to docker because docker-py is not maintained in pypi. This appears to have no effect
     "matplotlib==3.6",
     "networkx==2.8",


### PR DESCRIPTION
We have seen the error
```
snakemake\dag.py:1612: RuntimeWarning: coroutine 'DAG.sanitize_local_storage_copies' was never awaited
  self.sanitize_local_storage_copies()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

This was fixed in Snakemake pull request 2972 released in version 8.17.0.
```
https://github.com/snakemake/snakemake/pull/2972
https://github.com/snakemake/snakemake/pull/2960
```