### PR TITLE
chore: format docker errors

### DIFF
--- a/spras/containers.py
+++ b/spras/containers.py
@@ -2,6 +2,7 @@ import os
 import platform
 import re
 import subprocess
+import traceback
 from pathlib import Path, PurePath, PurePosixPath
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -166,7 +167,11 @@ def run_container_docker(container: str, command: List[str], volumes: List[Tuple
     out = None
     try:
         # Initialize a Docker client using environment variables
-        client = docker.from_env()
+        try:
+            client = docker.from_env()
+        except Exception as err:
+            err.add_note("An error occurred when fetching the docker daemon: is docker installed?")
+            raise err
         # Track the contents of the local directories that will be bound so that new files added can have their owner
         # changed
         pre_volume_contents = {}
@@ -233,7 +238,7 @@ def run_container_docker(container: str, command: List[str], volumes: List[Tuple
         client.close()
 
     except Exception as err:
-        print(err)
+        print(traceback.format_exc())
     # Removed the finally block to address bugbear B012
     # "`return` inside `finally` blocks cause exceptions to be silenced"
     # finally:


### PR DESCRIPTION
This adds a note for context (what errors are coming from wrapping the docker daemon, what are coming from actually running the container), and prints the stacktrace instead of just the error message.

(Didn't notice that I didn't have docker-in-docker installed, and encountered a confusing HTTP error since I didn't have docker installed in my developer environment.)