### PR TITLE
fix: check if required_inputs is iterable

### DIFF
--- a/spras/prm.py
+++ b/spras/prm.py
@@ -17,16 +17,16 @@ class PRM(ABC):
     @property
     @abstractmethod
     def required_inputs(self):
-        return NotImplementedError
+        raise NotImplementedError
 
     @abstractmethod
     def generate_inputs(self):
-        return NotImplementedError
+        raise NotImplementedError
 
     @abstractmethod
     def run(self):
-        return NotImplementedError
+        raise NotImplementedError
 
     @abstractmethod
     def parse_output(self):
-        return NotImplementedError
+        raise NotImplementedError

--- a/spras/runner.py
+++ b/spras/runner.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterable
+
 # supported algorithm imports
 from spras.allpairs import AllPairs as allpairs
 from spras.dataset import Dataset
@@ -30,7 +32,10 @@ def get_required_inputs(algorithm):
         algorithm_runner = globals()[algorithm.lower()]
     except KeyError as exc:
         raise NotImplementedError(f'{algorithm} is not currently supported') from exc
-    return algorithm_runner.required_inputs
+    if isinstance(algorithm_runner.required_inputs, Iterable):
+        return algorithm_runner.required_inputs
+    else:
+        raise TypeError(f"{algorithm}'s `required_inputs` property is not iterable - was `required_inputs` set?")
 
 
 def merge_input(dataset_dict, dataset_file):


### PR DESCRIPTION
If requested, this could possibly sanitize for correct required inputs, though I'm not sure if those would lead to some sort of terrible cyclic import and require extra refactoring.

This also raises `NotImplementedError`s instead of returning them in `prm.py` [I'm unsure if this is good or not.]