### PR TITLE
chore: restrict MEO to alpine

### DIFF
--- a/docker-wrappers/MEO/Dockerfile
+++ b/docker-wrappers/MEO/Dockerfile
@@ -1,6 +1,6 @@
 # Maximum Edge Orientation wrapper
 # https://github.com/agitter/meo/
-FROM openjdk:8
+FROM openjdk:8-alpine3.8
 
 WORKDIR /meo
 RUN export MEO_TAG=v1.1.0 && \

--- a/docker-wrappers/MEO/README.md
+++ b/docker-wrappers/MEO/README.md
@@ -21,4 +21,3 @@ The Docker wrapper can be tested with `pytest`.
 ## TODO
 - Attribute https://github.com/agitter/meo/
 - Document usage
-- Consider Alpine-based base image


### PR DESCRIPTION
All tests pass locally and MEO doesn't have external dependencies (other than Java 8).