### PR TITLE
refactor(dataset): drop unused edge_table parameter

### DIFF
--- a/spras/dataset.py
+++ b/spras/dataset.py
@@ -21,7 +21,6 @@ class Dataset:
         self.label = None
         self.interactome = None
         self.node_table = None
-        self.edge_table = None
         self.node_set = set()
         self.other_files = []
         self.load_files_from_dict(dataset_dict)
@@ -47,7 +46,7 @@ class Dataset:
         """
         Loads data files from dataset_dict, which is one dataset dictionary from the list
         in the config file with the fields in the config file.
-        Populates node_table, edge_table, and interactome.
+        Populates node_table and interactome.
 
         node_table is a single merged pandas table.
 

--- a/spras/evaluation.py
+++ b/spras/evaluation.py
@@ -14,7 +14,6 @@ class Evaluation:
         self.label = None
         self.datasets = None
         self.node_table = None
-        # self.edge_table = None TODO: later iteration
         self.load_files_from_dict(gold_standard_dict)
         return
 


### PR DESCRIPTION
This is the same idea as `self.interactome` and is both unused and never set to anything past `None.