### PR TITLE
refactor: cleanup prm

### DIFF
--- a/spras/allpairs.py
+++ b/spras/allpairs.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from spras.containers import prepare_volume, run_container_and_log
 from spras.dataset import Dataset
 from spras.interactome import reinsert_direction_col_undirected
-from spras.containers import prepare_volume, run_container_and_log
 from spras.prm import PRM
 from spras.util import add_rank_column, duplicate_edges, raw_pathway_df
 

--- a/spras/allpairs.py
+++ b/spras/allpairs.py
@@ -2,10 +2,8 @@ import warnings
 from pathlib import Path
 
 from spras.containers import prepare_volume, run_container
-from spras.interactome import (
-    convert_directed_to_undirected,
-    reinsert_direction_col_undirected,
-)
+from spras.dataset import Dataset
+from spras.interactome import reinsert_direction_col_undirected
 from spras.prm import PRM
 from spras.util import add_rank_column, duplicate_edges, raw_pathway_df
 
@@ -38,7 +36,7 @@ class AllPairs(PRM):
             warnings.warn(warn_msg, stacklevel=2)
 
         # Create nodetype file
-        input_df = sources_targets[["NODEID"]].copy()
+        input_df = sources_targets[[Dataset.NODE_ID]].copy()
         input_df.columns = ["#Node"]
         input_df.loc[sources_targets["sources"] == True, "Node type"] = "source"
         input_df.loc[sources_targets["targets"] == True, "Node type"] = "target"

--- a/spras/dataset.py
+++ b/spras/dataset.py
@@ -27,7 +27,7 @@ class Dataset:
         self.load_files_from_dict(dataset_dict)
         return
 
-    def to_file(self, file_name):
+    def to_file(self, file_name: str):
         """
         Saves dataset object to pickle file
         """
@@ -35,7 +35,7 @@ class Dataset:
             pkl.dump(self, f)
 
     @classmethod
-    def from_file(cls, file_name):
+    def from_file(cls, file_name: str):
         """
         Loads dataset object from a pickle file.
         Usage: dataset = Dataset.from_file(pickle_file)

--- a/spras/pathlinker.py
+++ b/spras/pathlinker.py
@@ -48,7 +48,7 @@ class PathLinker(PRM):
             warnings.warn(warn_msg, stacklevel=1)
 
         # Create nodetype file
-        input_df = sources_targets[Dataset.NODE_ID].copy()
+        input_df = sources_targets[[Dataset.NODE_ID]].copy()
         input_df.columns = ["#Node"]
         input_df.loc[sources_targets["sources"] == True,"Node type"]="source"
         input_df.loc[sources_targets["targets"] == True,"Node type"]="target"

--- a/spras/pathlinker.py
+++ b/spras/pathlinker.py
@@ -2,6 +2,7 @@ import warnings
 from pathlib import Path
 
 from spras.containers import prepare_volume, run_container
+from spras.dataset import Dataset
 from spras.interactome import (
     convert_undirected_to_directed,
     reinsert_direction_col_directed,
@@ -47,7 +48,7 @@ class PathLinker(PRM):
             warnings.warn(warn_msg, stacklevel=1)
 
         # Create nodetype file
-        input_df = sources_targets[["NODEID"]].copy()
+        input_df = sources_targets[Dataset.NODE_ID].copy()
         input_df.columns = ["#Node"]
         input_df.loc[sources_targets["sources"] == True,"Node type"]="source"
         input_df.loc[sources_targets["targets"] == True,"Node type"]="target"

--- a/spras/prm.py
+++ b/spras/prm.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 
 from spras.dataset import Dataset
 
+
 class PRM(ABC):
     """
     The PRM (Pathway Reconstruction Module) class,

--- a/spras/prm.py
+++ b/spras/prm.py
@@ -1,32 +1,33 @@
-#
-# Implement an abstract PRM class
-#
-#
 from abc import ABC, abstractmethod
 
+from spras.dataset import Dataset
 
 class PRM(ABC):
-    def __init__(self, params):
-        self.name = params['name']
-        self.inputdir = params['inputdir']
-        self.outputdir = params['outputdir']
-        self.params = params['params']
-        # debugging
-        #print('Params:',self.params)
+    """
+    The PRM (Pathway Reconstruction Module) class,
+    which defines the interface that `runner.py` uses to handle
+    algorithms.
+    """
 
     @property
+    @staticmethod
     @abstractmethod
     def required_inputs(self):
-        return NotImplementedError
+        # Note: This NotImplementedError will never trigger.
+        # See CONTRIBUTING.md for more information.
+        raise NotImplementedError
 
+    @staticmethod
     @abstractmethod
-    def generate_inputs(self):
-        return NotImplementedError
+    def generate_inputs(data: Dataset, filename_map: dict[str, str]):
+        raise NotImplementedError
 
+    @staticmethod
     @abstractmethod
-    def run(self):
-        return NotImplementedError
+    def run(**kwargs):
+        raise NotImplementedError
 
+    @staticmethod
     @abstractmethod
-    def parse_output(self):
-        return NotImplementedError
+    def parse_output(raw_pathway_file: str, standardized_pathway_file: str):
+        raise NotImplementedError

--- a/spras/runner.py
+++ b/spras/runner.py
@@ -9,7 +9,7 @@ from spras.omicsintegrator2 import OmicsIntegrator2 as omicsintegrator2
 from spras.pathlinker import PathLinker as pathlinker
 
 
-def run(algorithm, params):
+def run(algorithm: str, params):
     """
     A generic interface to the algorithm-specific run functions
     """
@@ -20,7 +20,7 @@ def run(algorithm, params):
     algorithm_runner.run(**params)
 
 
-def get_required_inputs(algorithm):
+def get_required_inputs(algorithm: str):
     """
     Get the input files requires to run this algorithm
     @param algorithm: algorithm name
@@ -33,7 +33,7 @@ def get_required_inputs(algorithm):
     return algorithm_runner.required_inputs
 
 
-def merge_input(dataset_dict, dataset_file):
+def merge_input(dataset_dict, dataset_file: str):
     """
     Merge files listed for this dataset and write the dataset to disk
     @param dataset_dict: dataset to process
@@ -43,7 +43,7 @@ def merge_input(dataset_dict, dataset_file):
     dataset.to_file(dataset_file)
 
 
-def prepare_inputs(algorithm, data_file, filename_map):
+def prepare_inputs(algorithm: str, data_file: str, filename_map: dict[str, str]):
     """
     Prepare general dataset files for this algorithm
     @param algorithm: algorithm name
@@ -59,7 +59,7 @@ def prepare_inputs(algorithm, data_file, filename_map):
     return algorithm_runner.generate_inputs(dataset, filename_map)
 
 
-def parse_output(algorithm, raw_pathway_file, standardized_pathway_file):
+def parse_output(algorithm: str, raw_pathway_file: str, standardized_pathway_file: str):
     """
     Convert a predicted pathway into the universal format
     @param algorithm: algorithm name


### PR DESCRIPTION
Adds global type-hints related to PRM, and corrects the NotImplementedError error handling inside PRM.

This also takes the chance to update "NODEID" calls to Dataset.NODEID.