### PR TITLE
fix(singularity): mv unpacked files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,5 +142,5 @@ TempMat.mat
 # OSX-specific stuff
 **/.DS_Store
 
-# SPRAS singularity container
-spras.sif
+# Singularity cache
+unpacked

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,7 +14,8 @@ container_framework: docker
 # such as would be the case in an HTCondor/OSPool environment.
 # NOTE: This unpacks singularity containers to the local filesystem, which will take up space in a way
 # that persists after the workflow is complete. To clean up the unpacked containers, the user must
-# manually delete them.
+# manually delete them. For convenience, these unpacked files will exist in the current working directory
+# under `unpacked`.
 unpack_singularity: false
 
 # Allow the user to configure which container registry containers should be pulled from


### PR DESCRIPTION
This is a follow-up to https://github.com/Reed-CompBio/spras/pull/145#issuecomment-1970044310, taking the neutral approach where GC is left up to the user, but in such a way where it is made convenient. This addresses the `allpairs` creating git-commitable artifacts on the cwd.

This path could be made a parameter in the encompassing `run_container_singularity` function, though that seems out of scope for SPRAS itself.

[The commit name is misleading - it should be `mv`, not `gc`.]