### PR TITLE
fix: supply correct oi1 flag

### DIFF
--- a/spras/omicsintegrator1.py
+++ b/spras/omicsintegrator1.py
@@ -167,10 +167,10 @@ class OmicsIntegrator1(PRM):
         if dummy_mode is not None and dummy_mode:
             # for custom dummy modes, add the file
             if dummy_mode == 'file':
-                command.extend(['--dummy', dummy_file])
+                command.extend(['--dummyMode', dummy_file])
             # else pass in the dummy_mode and let oi1 handle it
             else:
-                command.extend(['--dummy', dummy_mode])
+                command.extend(['--dummyMode', dummy_mode])
 
         # Add optional arguments
         if mu_squared is not None and mu_squared:


### PR DESCRIPTION
See https://github.com/fraenkel-lab/OmicsIntegrator/blob/0a57ede6beeef6e63b86d19898e560d62015e85d/scripts/forest.py#L1348-L1353. Debugged by @AMINOexe. The attached GitHub link links to the commit we use in the OI1 Dockerfile: https://github.com/Reed-CompBio/spras/blob/326a5e6f7fbd9a77c8e42384595a658678530652/docker-wrappers/OmicsIntegrator1/Dockerfile#L12

[Incorrectly flagged as needed for benchmarking, turns out dummyMode as terminals works just fine for our purposes. This should still be fixed.]

Since OI1 is random, we unfortunately can not test for correctness.