### PR TITLE
test: make sure all inputs exist

### DIFF
--- a/test/generate-inputs/test_generate_inputs.py
+++ b/test/generate-inputs/test_generate_inputs.py
@@ -49,6 +49,6 @@ class TestGenerateInputs:
             exp_file_name = algo_exp_file[algo]
             assert filecmp.cmp(OUTDIR + f"{algo}-{exp_file_name}.txt", EXPDIR + f"{algo}-{exp_file_name}-expected.txt",
                                shallow=False)
-            
+
             for file in filename_map.values():
                 assert Path(file).exists()

--- a/test/generate-inputs/test_generate_inputs.py
+++ b/test/generate-inputs/test_generate_inputs.py
@@ -49,3 +49,6 @@ class TestGenerateInputs:
             exp_file_name = algo_exp_file[algo]
             assert filecmp.cmp(OUTDIR + f"{algo}-{exp_file_name}.txt", EXPDIR + f"{algo}-{exp_file_name}-expected.txt",
                                shallow=False)
+            
+            for file in filename_map.values():
+                assert Path(file).exists()


### PR DESCRIPTION
This catches the error that occurred in #223 earlier than after the docker container is ran.