### PR TITLE
refactor(runner): rn prepare -> generate_inputs

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -189,7 +189,7 @@ checkpoint prepare_input:
         # and write the output files specified by required_inputs
         # The filename_map provides the output file path for each required input file type
         filename_map = {input_type: SEP.join([out_dir, 'prepared', f'{wildcards.dataset}-{wildcards.algorithm}-inputs', f'{input_type}.txt']) for input_type in runner.get_required_inputs(wildcards.algorithm)}
-        runner.prepare_inputs(wildcards.algorithm, input.dataset_file, filename_map)
+        runner.generate_inputs(wildcards.algorithm, input.dataset_file, filename_map)
 
 # Collect the prepared input files from the specified directory
 # If the directory does not exist for this dataset-algorithm pair, the checkpoint will detect that

--- a/spras/runner.py
+++ b/spras/runner.py
@@ -48,7 +48,7 @@ def merge_input(dataset_dict, dataset_file: str):
     dataset.to_file(dataset_file)
 
 
-def prepare_inputs(algorithm: str, data_file: str, filename_map: dict[str, str]):
+def generate_inputs(algorithm: str, data_file: str, filename_map: dict[str, str]):
     """
     Prepare general dataset files for this algorithm
     @param algorithm: algorithm name

--- a/test/generate-inputs/test_generate_inputs.py
+++ b/test/generate-inputs/test_generate_inputs.py
@@ -31,7 +31,7 @@ class TestGenerateInputs:
         """
         Path(OUTDIR).mkdir(parents=True, exist_ok=True)
 
-    def test_prepare_inputs_networks(self):
+    def test_generate_inputs_networks(self):
         config_loc = os.path.join("test", "generate-inputs", "inputs", "test_config.yaml")
 
         with open(config_loc) as config_file:
@@ -45,7 +45,7 @@ class TestGenerateInputs:
             inputs = runner.get_required_inputs(algo)
             filename_map = {input_str: os.path.join("test", "generate-inputs", "output", f"{algo}-{input_str}.txt")
                             for input_str in inputs}
-            runner.prepare_inputs(algo, test_file, filename_map)
+            runner.generate_inputs(algo, test_file, filename_map)
             exp_file_name = algo_exp_file[algo]
             assert filecmp.cmp(OUTDIR + f"{algo}-{exp_file_name}.txt", EXPDIR + f"{algo}-{exp_file_name}-expected.txt",
                                shallow=False)


### PR DESCRIPTION
Closes #262. `generate_inputs` in `runner.py`, `prepare_inputs` in Snakemake.