### PR TITLE
docs: light reorganization

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,9 @@
 Welcome to SPRAS's documentation!
 =================================
 
-SPRAS is a Python package that builds on Snakemake and Docker to provide a standardized, reproducible, and scalable framework for applying pathway reconstruction
+SPRAS is a Python package that builds on `Snakemake <https://snakemake.readthedocs.io>`_ and
+`Docker <https://en.wikipedia.org/wiki/Docker_(software)>`_ to provide a standardized,
+reproducible, and scalable framework for applying pathway reconstruction
 methods (PRMs) to omics data.
 
 .. image:: _static/spras-overview.png
@@ -27,7 +29,12 @@ methods (PRMs) to omics data.
 
    about
    install
-   vignettes
+   usage
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Manual
+
    output
 
 .. toctree::

--- a/docs/output.rst
+++ b/docs/output.rst
@@ -9,8 +9,8 @@ and rows providing attributes for each edge. The header row is
 ``Node1    Node2   Rank    Direction``. Each row lists the two nodes
 that are connected with an edge, the rank for that edge, and a
 directionality column to indicate whether the edge is directed or
-undirected. The directionality values are either a ‘U’ for an undirected
-edge or a ‘D’ for a directed edge, where the direction is from Node1 to
+undirected. The directionality values are either a 'U' for an undirected
+edge or a 'D' for a directed edge, where the direction is from Node1 to
 Node2. Pathways that do not contain ranked edges can output all 1s in
 the Rank column.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,12 @@
+Using SPRAS
+===========
+
+SPRAS is run through `Snakemake <https://snakemake.readthedocs.io/>`_, which comes
+with the SPRAS conda environment.
+
+To run SPRAS, run the following command inside the ``spras`` directory,
+specifying a ``config.yaml`` and the number of cores to run SPRAS with:
+
+.. code-block:: bash
+
+    snakemake --cores 1 --configfile config.yaml

--- a/docs/vignettes.rst
+++ b/docs/vignettes.rst
@@ -1,5 +1,0 @@
-SPRAS Python Vignettes
-======================
-
-Here are some nice vignettes explaining how *you* can run SPRAS against your own datasets
-to do your awesome and revolutionary science!


### PR DESCRIPTION
Establishes a pattern of "Getting Started" for introduction, and "Manual" for more involved usage.

I avoid populating `docs/usage.rst` here, since I suspect that #332, #292, and #329 might be really useful for external contributors. (We can automatically document `config.yaml` properties through Pydantic, and avoid downstream users for having to explicitly specify using the SPRAS snakefile)