### PR TITLE
chore: bump btb

### DIFF
--- a/docker-wrappers/BowTieBuilder/Dockerfile
+++ b/docker-wrappers/BowTieBuilder/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.8-bullseye
 
 WORKDIR /btb
-RUN wget https://raw.githubusercontent.com/Reed-CompBio/BowTieBuilder-Algorithm/dd8519cd8a8397c0e0724106f498b6002d3f7be2/btb.py
+RUN wget https://raw.githubusercontent.com/Reed-CompBio/BowTieBuilder-Algorithm/b570b85a1f06ab3b3eb56cd3ba00b802f3d4deaf/btb.py
 RUN pip install networkx==2.8


### PR DESCRIPTION
Changes: https://github.com/Reed-Compbio/BowTieBuilder-algorithm/compare/0c8f9f56e0b15068e47864d0ecadbcdefa3af860...Reed-CompBio:b570b85a1f06ab3b3eb56cd3ba00b802f3d4deaf#diff-66129c30b559c422b07a13bb06484e039784798797415eeabc2cbe6dae77b0e2R390-R395

BTB is still long-running, but the EGFR test case no longer takes >4 hours, just 11 minutes.