### PR TITLE
docs: display "edit on github" links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,4 +43,10 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'sphinx_rtd_theme'
+html_context = {
+    "display_github": True,
+    "github_user": "Reed-CompBio",
+    "github_repo": "spras",
+    "github_version": "main/docs/",
+}
 html_static_path = ['_static']


### PR DESCRIPTION
(This takes you to https://github.com/Reed-CompBio/spras/blob/main/docs/usage.rst).

<img width="739" height="337" alt="image" src="https://github.com/user-attachments/assets/2b748361-7848-47ac-a279-00d8a45606e8" />
