### PR TITLE
ci: use pre-commit from conda

### DIFF
--- a/.github/workflows/test-spras.yml
+++ b/.github/workflows/test-spras.yml
@@ -72,10 +72,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11' # Match this to the version specified in environment.yml
       - name: Install conda environment
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/test-spras.yml
+++ b/.github/workflows/test-spras.yml
@@ -76,5 +76,14 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11' # Match this to the version specified in environment.yml
-      - name: Run pre-commit checks
-        uses: pre-commit/action@v3.0.0
+      - name: Install conda environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: spras
+          environment-file: environment.yml
+          auto-activate-base: false
+          miniconda-version: 'latest'
+      - name: Run pre-commit
+        shell: bash --login {0}
+        # https://github.com/pre-commit/action/blob/576ff52938d158a24ac7e009dfa94b1455e7df99/action.yml#L19
+        run: pre-commit run --show-diff-on-failure --color=always

--- a/spras/omicsintegrator1.py
+++ b/spras/omicsintegrator1.py
@@ -120,7 +120,7 @@ class OmicsIntegrator1(PRM):
         @param w: float that affects the number of connected components, with higher values leading to more components
         @param b: the trade-off between including more prizes and using less reliable edges
         @param d: controls the maximum path-length from root to terminal nodes
-        @param mu: controls the degree-based negative prizes (defualt 0.0)
+        @param mu: controls the degree-based negative prizes (default 0.0)
         @param noise: Standard Deviation of the gaussian noise added to edges in Noisy Edges Randomizations
         @param g: Gamma: multiplicative edge penalty from degree of endpoints
         @param r: msgsteiner parameter that adds random noise to edges, which is rarely needed (default 0)


### PR DESCRIPTION
Fixes the `main` typo, and closes #351.