### PR TITLE
fix: Roll back typos to rev 1.25.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,11 @@ repos:
     hooks:
       # Attempts to load all yaml files to verify syntax.
       - id: check-yaml
-      # Attempts to load all TOML files to verify syntax.
       - id: check-toml
-      # Trims trailing whitespace.
+        # Attempts to load all TOML files to verify syntax.
       - id: trailing-whitespace
         # Preserves Markdown hard linebreaks.
+        # Trims trailing whitespace.
         args: [--markdown-linebreak-ext=md]
         # Do not trim whitespace from all files, input files may need trailing whitespace for empty values in columns.
         types_or: [markdown, python, yaml]
@@ -29,6 +29,6 @@ repos:
     hooks:
       - id: yamlfmt
   - repo: https://github.com/crate-ci/typos
-    rev: v1.34.0
+    rev: v1.25.0
     hooks:
       - id: typos

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,11 @@ repos:
     hooks:
       # Attempts to load all yaml files to verify syntax.
       - id: check-yaml
-      - id: check-toml
         # Attempts to load all TOML files to verify syntax.
+      - id: check-toml
+        # Trims trailing whitespace.
       - id: trailing-whitespace
         # Preserves Markdown hard linebreaks.
-        # Trims trailing whitespace.
         args: [--markdown-linebreak-ext=md]
         # Do not trim whitespace from all files, input files may need trailing whitespace for empty values in columns.
         types_or: [markdown, python, yaml]


### PR DESCRIPTION
The following [version](https://github.com/crate-ci/typos/releases/tag/v1.26.0) resolves the deprecated pre-commit stage names so we need this [version](https://github.com/crate-ci/typos/releases/tag/v1.25.0) until we upgrade pre-commit. See also `https://github.com/crate-ci/typos/pull/1114`.

Follow up to #347.