### PR TITLE
fix: make merged files less ambigious

### DIFF
--- a/.github/workflows/test-spras.yml
+++ b/.github/workflows/test-spras.yml
@@ -63,7 +63,8 @@ jobs:
         run: pytest -vs
       - name: Run Snakemake workflow
         shell: bash --login {0}
-        run: snakemake --cores 2 --configfile config/config.yaml --show-failed-logs
+        # We enforce strict DAG evaluation to catch DAG problems before they appear as user errors.
+        run: snakemake --cores 2 --configfile config/config.yaml --show-failed-logs --strict-dag-evaluation cyclic-graph --strict-dag-evaluation functions --strict-dag-evaluation periodic-wildcards
 
   # Run pre-commit checks on source files
   pre-commit:

--- a/Snakefile
+++ b/Snakefile
@@ -158,7 +158,7 @@ def get_dataset_dependencies(wildcards):
 rule merge_input:
     # Depends on the node, edge, and other files for this dataset so the rule and downstream rules are rerun if they change
     input: get_dataset_dependencies
-    output: dataset_file = SEP.join([out_dir, '{dataset}-merged.pickle'])
+    output: dataset_file = SEP.join([out_dir, 'dataset-{dataset}-merged.pickle'])
     run:
         # Pass the dataset to PRRunner where the files will be merged and written to disk (i.e. pickled)
         dataset_dict = get_dataset(_config.config.datasets, wildcards.dataset)
@@ -174,7 +174,7 @@ def get_gold_standard_dependencies(wildcards):
 # Merge all node files for a gold_standard into a single node table
 rule merge_gs_input:
     input: get_gold_standard_dependencies
-    output: gold_standard_file = SEP.join([out_dir, '{gold_standard}-merged.pickle'])
+    output: gold_standard_file = SEP.join([out_dir, 'gs-{gold_standard}-merged.pickle'])
     run:
         gold_standard_dict = get_dataset(_config.config.gold_standards, wildcards.gold_standard)
         Evaluation.merge_gold_standard_input(gold_standard_dict, output.gold_standard_file)
@@ -186,7 +186,7 @@ rule merge_gs_input:
 # The checkpoint produces a directory instead of a list of output files because the number and types of output
 # files is algorithm-dependent
 checkpoint prepare_input:
-    input: dataset_file = SEP.join([out_dir, '{dataset}-merged.pickle'])
+    input: dataset_file = SEP.join([out_dir, 'dataset-{dataset}-merged.pickle'])
     # Output is a directory that will contain all prepared files for pathway reconstruction
     output: output_dir = directory(SEP.join([out_dir, 'prepared', '{dataset}-{algorithm}-inputs']))
     # Run the preprocessing script for this algorithm
@@ -275,7 +275,7 @@ rule reconstruct:
 rule parse_output:
     input: 
         raw_file = SEP.join([out_dir, '{dataset}-{algorithm}-{params}', 'raw-pathway.txt']),
-        dataset_file = SEP.join([out_dir, '{dataset}-merged.pickle'])
+        dataset_file = SEP.join([out_dir, 'dataset-{dataset}-merged.pickle'])
     output: standardized_file = SEP.join([out_dir, '{dataset}-{algorithm}-{params}', 'pathway.txt'])
     run:
         params = reconstruction_params(wildcards.algorithm, wildcards.params).copy()
@@ -307,7 +307,7 @@ rule summary_table:
     input:
         # Collect all pathways generated for the dataset
         pathways = expand('{out_dir}{sep}{{dataset}}-{algorithm_params}{sep}pathway.txt', out_dir=out_dir, sep=SEP, algorithm_params=algorithms_with_params),
-        dataset_file = SEP.join([out_dir, '{dataset}-merged.pickle'])
+        dataset_file = SEP.join([out_dir, 'dataset-{dataset}-merged.pickle'])
     output: summary_table = SEP.join([out_dir, '{dataset}-pathway-summary.txt'])
     run:
         # Load the node table from the pickled dataset file
@@ -404,7 +404,7 @@ rule jaccard_similarity_per_algo:
 def get_gold_standard_pickle_file(wildcards):
     parts = wildcards.dataset_gold_standard_pairs.split('-')
     gs = parts[1]
-    return SEP.join([out_dir, f'{gs}-merged.pickle'])
+    return SEP.join([out_dir, f'gs-{gs}-merged.pickle'])
 
 # Returns the dataset corresponding to the gold standard pair
 def get_dataset_label(wildcards):
@@ -461,7 +461,7 @@ rule evaluation_per_algo_pca_chosen:
 # Return the dataset pickle file for a specific dataset
 def get_dataset_pickle_file(wildcards):
     dataset_label = get_dataset_label(wildcards)
-    return SEP.join([out_dir, f'{dataset_label}-merged.pickle'])
+    return SEP.join([out_dir, f'dataset-{dataset_label}-merged.pickle'])
 
 # Returns ensemble file for each dataset
 def collect_ensemble_per_dataset(wildcards):


### PR DESCRIPTION
We also add `--strict-dag-evaluation cyclic-graph --strict-dag-evaluation functions --strict-dag-evaluation periodic-wildcards` in CI to catch these errors before they happen again.