### PR TITLE
fix: preserve pathway.txt files

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -113,10 +113,8 @@ def make_final_input(wildcards):
         final_input.extend(expand('{out_dir}{sep}{dataset_gold_standard_pair}-eval{sep}pr-curve-ensemble-nodes-per-algorithm.png',out_dir=out_dir,sep=SEP,dataset_gold_standard_pair=dataset_gold_standard_pairs))
         final_input.extend(expand('{out_dir}{sep}{dataset_gold_standard_pair}-eval{sep}pr-curve-ensemble-nodes-per-algorithm.txt',out_dir=out_dir,sep=SEP,dataset_gold_standard_pair=dataset_gold_standard_pairs))
 
-    if len(final_input) == 0:
-        # No analysis added yet, so add reconstruction output files if they exist.
-        # (if analysis is specified, these should be implicitly run).
-        final_input.extend(expand('{out_dir}{sep}{dataset}-{algorithm_params}{sep}pathway.txt', out_dir=out_dir, sep=SEP, dataset=dataset_labels, algorithm_params=algorithms_with_params))
+    # Since (formatted) pathway files are interesting to the user, we preserve them.
+    final_input.extend(expand('{out_dir}{sep}{dataset}-{algorithm_params}{sep}pathway.txt', out_dir=out_dir, sep=SEP, dataset=dataset_labels, algorithm_params=algorithms_with_params))
 
     # Create log files for the parameters and datasets
     final_input.extend(expand('{out_dir}{sep}logs{sep}parameters-{algorithm_params}.yaml', out_dir=out_dir, sep=SEP, algorithm_params=algorithms_with_params))


### PR DESCRIPTION
`pathway.txt` is an interesting intermediary file, regardless of whether downstream analysis is enabled or not.

This rule change means that `pathway.txt` now gets recreated if it gets deleted.