### PR TITLE
ci: use main branch

### DIFF
--- a/.github/workflows/build-and-remove-template.yml
+++ b/.github/workflows/build-and-remove-template.yml
@@ -32,13 +32,13 @@ jobs:
         uses: actions/checkout@v2
 
       # Given the input path to the directory containing definitions of the container,
-      # check whether anything at that path has been modified relative to master's head.
+      # check whether anything at that path has been modified relative to main's head.
       # If so, we'll set `env.changed=true` to trigger the build in a later step
       - name: Check for changes
         if: ${{ inputs.always_build == false }}
         id: check_changes
         run: |
-          if git fetch origin master && git diff --name-only origin/master | grep -q "$(basename ${{ inputs.path }})"; then
+          if git fetch origin main && git diff --name-only origin/main | grep -q "$(basename ${{ inputs.path }})"; then
             echo "Changes detected to ${{inputs.path}}."
             echo "changed=true" >> $GITHUB_ENV
           else

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build-and-remove-omics1:

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -406,7 +406,7 @@ them, you can open a `GitHub
 issue <https://github.com/Reed-CompBio/spras/issues/new/choose>`__ to
 request feedback. However, once the pull request has been approved, it
 will **not** be merged as usual. The pull request will be closed so that
-the ``master`` branch of the fork stays synchronized with the ``master``
+the ``main`` branch of the fork stays synchronized with the ``main``
 branch of the main SPRAS repository.
 
 General steps for contributing a new pathway reconstruction algorithm


### PR DESCRIPTION
Leftover from #8 that silently killed `build-and-remove-template.yml`. Also corrects the branch name in docs.