### PR TITLE
docs(devcontainer): apptainer over singularity

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -8,11 +8,11 @@ Devcontainers can be launched in Visual Studio Code (not VSCodium!), through [Je
 through [GitHub Codespaces](https://github.com/features/codespaces), a [coder](https://coder.com/) instance,
 or with [GitPod](https://www.gitpod.io/docs/gitpod/configuration/devcontainer/overview).
 
-## Building Singularity
+## Building Apptainer
 
-Since this takes a good while, building singularity is an external script one can run
-inside the devcontainer, but `go` and the associated `apt` dependencies are already present in
-the Dockerfile, and, consequently, the container.
+Since building apptainer takes a while, we leave building apptainer as an external script one can run
+inside the devcontainer, but `go` and other necessary dependencies to build `apptainer` are already present in
+the devcontaier Dockerfile.
 
 Below is a shell script which will do the entire installation for you (but it will change your
 shell's CWD):
@@ -20,12 +20,15 @@ shell's CWD):
 ```sh
 cd /
 # sudo is required since we are in root
-sudo git clone --recurse-submodules https://github.com/sylabs/singularity.git
-# but we would like to use singularity normally
-sudo chown -R vscode: /singularity/
-cd /singularity
-git checkout --recurse-submodules v4.3.1 # pin version
-./mconfig --without-libsubid # dev container limitation
-make -C builddir
-sudo make -C builddir install
+sudo git clone https://github.com/apptainer/apptainer.git
+# but we would like to use apptainer normally
+sudo chown -R $(whoami): /apptainer/
+cd /apptainer
+git checkout v1.4.2 # pin version
+./mconfig --without-libsubid --with-suid # --without-libsubid is a dev container limitation
+cd $(/bin/pwd)/builddir
+make
+sudo make install
 ```
+
+After this, run `apptainer` to confirm your installation.


### PR DESCRIPTION
[I am currently confirming that this works inside a freshly made GitHub Codespaces, and is compatible with the current use of singularity in SPRAS]

We should start preferring using apptainer in the repository.