### PR TITLE
ci: label merge conflicts

### DIFF
--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -1,0 +1,17 @@
+name: Label merge conflicts
+
+on:
+  schedule:
+    - cron: '*/30 * * * *' # run every 30 minutes
+  workflow_dispatch:
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    if: github.repository == 'Reed-CompBio/spras'
+    steps:
+      - name: Check for PR merge conflicts
+        uses: eps1lon/actions-label-merge-conflict@1df065ebe6e3310545d4f4c4e862e43bdca146f0 # v3.0.3
+        with:
+          dirtyLabel: "merge-conflict"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -1,8 +1,16 @@
 name: Label merge conflicts
 
 on:
+  # Event descriptions are all from https://github.com/eps1lon/actions-label-merge-conflict/:
+  # So that PRs touching the same files as the push are updated
+  push:
+  # So that the `dirtyLabel` is removed if conflicts are resolve
+  # We recommend `pull_request_target` so that github secrets are available.
+  # In `pull_request` we wouldn't be able to change labels of fork PRs
+  pull_request_target:
+    types: [synchronize]
   schedule:
-    - cron: '*/30 * * * *' # run every 30 minutes
+    - cron: '0 * * * *' # run every hour
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Labels merge conflicts on open PRs. Frozen to a commit hash since this isn't an officially maintained GitHub action.