### PR TITLE
docs(APSP): Link to current location of APSP source

### DIFF
--- a/config/egfr.yaml
+++ b/config/egfr.yaml
@@ -65,6 +65,11 @@ algorithms:
           - 2
         g:
           - 3
+      run3:
+        b:
+          - 3
+        g:
+          - 3
   - name: meo
     params:
       include: true

--- a/config/egfr.yaml
+++ b/config/egfr.yaml
@@ -65,11 +65,6 @@ algorithms:
           - 2
         g:
           - 3
-      run3:
-        b:
-          - 3
-        g:
-          - 3
   - name: meo
     params:
       include: true

--- a/docker-wrappers/AllPairs/README.md
+++ b/docker-wrappers/AllPairs/README.md
@@ -1,7 +1,7 @@
 # All Pairs Shortest Paths Docker image
 
 A Docker image for All Pairs Shortest Paths that is available on [DockerHub](https://hub.docker.com/repository/docker/reedcompbio/allpairs).
-This algorithm was implemented by the SPRAS team and relies on the NetworkX [`shortest_path`](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.shortest_paths.generic.shortest_path.html) function.
+This [algorithm](https://github.com/Reed-CompBio/all-pairs-shortest-paths) was implemented by the SPRAS team and relies on the NetworkX [`shortest_path`](https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.shortest_paths.generic.shortest_path.html) function.
 
 To create the Docker image run:
 ```
@@ -24,7 +24,6 @@ The Docker wrapper can be tested with `pytest -k test_ap.py` from the root of th
 
 
 ## Notes
-- The `all-pairs-shortest-paths.py` code is located locally in SPRAS (since the code is short). It is under `docker-wrappers/AllPairs`.
 - Samples of an input network and source/target file are located under test/AllPairs/input.
 
 ## Versions:


### PR DESCRIPTION
The readme incorrectly states the source is in the SPRAS repo