### PR TITLE
chore(environment.yml): bump pip

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   - tabulate=0.9.0
 
   # toolchain deps
-  - pip=22.1
+  - pip=25.2
   # This should be the same as requires-python minus the >=.
   - python=3.11
 


### PR DESCRIPTION
Also superseded by #382. Attempted fix for #373. Note that `pyproject.toml` uses this version of `pip`.