### PR TITLE
test(btb): drop useless pathloading

### DIFF
--- a/test/BowTieBuilder/test_btb.py
+++ b/test/BowTieBuilder/test_btb.py
@@ -1,9 +1,10 @@
 import shutil
 from pathlib import Path
+
 import pytest
 
-from spras.btb import BowTieBuilder as BTB
 import spras.config.config as config
+from spras.btb import BowTieBuilder as BTB
 
 config.init_from_file("config/config.yaml")
 


### PR DESCRIPTION
Cleans up #250. Leftover from copied LocalNeighborhood code, spotted in #391.