### PR TITLE
ci: don't fail fast

### DIFF
--- a/.github/workflows/test-spras.yml
+++ b/.github/workflows/test-spras.yml
@@ -36,6 +36,8 @@ jobs:
         # (with the max specified by `--splits 2`), to save CI time by parallelization
         test_group: [1, 2]
         os: [ubuntu-latest]
+      # we want all tests to run, even if some fail.
+      fail-fast: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Without this, the other test split will stop if one of the tests fail in the first split. This is annoying when more than one test fails [this is mainly just for helping deal with flaky tests.]