### PR TITLE
fix(meo): use non-deprecated base image

### DIFF
--- a/docker-wrappers/MEO/Dockerfile
+++ b/docker-wrappers/MEO/Dockerfile
@@ -1,14 +1,7 @@
 # Maximum Edge Orientation wrapper
 # https://github.com/agitter/meo/
-FROM openjdk:8
+FROM amazoncorretto:8-alpine3.19
 
 WORKDIR /meo
 RUN export MEO_TAG=v1.1.0 && \
     wget https://raw.githubusercontent.com/agitter/meo/$MEO_TAG/EOMain.jar
-
-# Provide only the properties file as an argument to the jar file
-# No longer set an ENTRYPOINT so that singularity exec can be used in addition to docker run
-# ENTRYPOINT ["java", "-jar", "/meo/EOMain.jar"]
-
-# Pass the entire command and properties file:
-# java -jar /meo/EOMain.jar <properties_file>

--- a/docker-wrappers/MEO/README.md
+++ b/docker-wrappers/MEO/README.md
@@ -21,4 +21,8 @@ The Docker wrapper can be tested with `pytest`.
 ## TODO
 - Attribute https://github.com/agitter/meo/
 - Document usage
-- Consider Alpine-based base image
+
+## Versions
+
+- `v1`: Initial version
+- `v2`: Use `amazoncorretto` alpine base image

--- a/spras/meo.py
+++ b/spras/meo.py
@@ -178,7 +178,7 @@ class MEO(PRM):
 
         command = ['java', '-jar', '/meo/EOMain.jar', properties_file]
 
-        container_suffix = "meo"
+        container_suffix = "meo:v2"
         run_container_and_log('Maximum Edge Orientation',
                              container_framework,
                              container_suffix,


### PR DESCRIPTION
OpenJDK pulled versions `8` and `11` from DockerHub sometime ago. These containers no longer build.

(Sorry @jhiemstrawisc! I forgot you don't have access to DockerHub.)

---

This is in the review queue since it breaks CI, which is happening in #329.