### PR TITLE
chore(btb): slim

### DIFF
--- a/docker-wrappers/BowTieBuilder/Dockerfile
+++ b/docker-wrappers/BowTieBuilder/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.8-bullseye
+FROM python:3.8-alpine
+
+RUN apk add --no-cache git
 
 WORKDIR /btb
 RUN wget https://raw.githubusercontent.com/Reed-CompBio/BowTieBuilder-Algorithm/dd8519cd8a8397c0e0724106f498b6002d3f7be2/btb.py


### PR DESCRIPTION
BowTieBuilder depends on the non-wheel-based networkx, so this can be safely moved to alpine without incurring a performance penalty. This was encouraged by #448.

- Depends on #344? I think BTB:v2 is #344.