### PR TITLE
fix: don't have overlapping jaccard similary matrix text

### DIFF
--- a/spras/analysis/ml.py
+++ b/spras/analysis/ml.py
@@ -459,8 +459,11 @@ def jaccard_similarity_eval(summary_df: pd.DataFrame, output_file: str | PathLik
     ax.set_yticklabels(algorithms)
     plt.colorbar(cax, ax=ax)
     # annotate each cell with the corresponding similarity value
+    # where we set the precision to be lower as the number of algorithms increases
+    n = 2
+    if len(algorithms) > 10: n = 1
     for i in range(len(algorithms)):
         for j in range(len(algorithms)):
-            ax.text(j, i, f'{jaccard_matrix.values[i, j]:.2f}', ha='center', va='center', color='white')
+            ax.text(j, i, f'{jaccard_matrix.values[i, j]:.{n}f}', ha='center', va='center', color='white')
     plt.savefig(output_png, bbox_inches="tight", dpi=DPI)
     plt.close()


### PR DESCRIPTION
10 is notably a magic value.

<img width="2882" height="2652" alt="jaccard-heatmap" src="https://github.com/user-attachments/assets/416fc50b-5edb-4a21-bbd0-b107fe4431cd" />
<img width="2882" height="2652" alt="jaccard-heatmap-second" src="https://github.com/user-attachments/assets/4288b264-abc5-4202-84d9-0d6f4896b015" />
