### PR TITLE
docs: rstfmt on Windows

### DIFF
--- a/docs/contributing/maintain.rst
+++ b/docs/contributing/maintain.rst
@@ -2,9 +2,9 @@
  Maintaining SPRAS
 ###################
 
-************************
- precommit dependencies
-************************
+*************************
+ pre-commit dependencies
+*************************
 
 The ``yamlfmt`` tool requires `Go <https://go.dev/doc/install>`__, which
 must be installed manually. The ``rstfmt`` format tools must be able to

--- a/docs/contributing/maintain.rst
+++ b/docs/contributing/maintain.rst
@@ -2,12 +2,14 @@
  Maintaining SPRAS
 ###################
 
-***************
- Go dependency
-***************
+************************
+ precommit dependencies
+************************
 
 The ``yamlfmt`` tool requires `Go <https://go.dev/doc/install>`__, which
-must be installed manually.
+must be installed manually. The ``rstfmt`` format tools must be able to
+read UTF-8 encoded text, which requires manually setting the environment
+variable ``PYTHONUTF8`` to ``1`` on Windows.
 
 ********************
  Naming conventions


### PR DESCRIPTION
precommit broke locally on Windows after #467 because Windows has a different default text encoding.