### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spras"
-version = "0.6.0"
+version = "0.7.0"
 description = "Signaling Pathway Reconstruction Analysis Streamliner"
 authors = [
   { name = "Anthony Gitter", email = "gitter@biostat.wisc.edu" },


### PR DESCRIPTION
I'm choosing to not update all the docs like in #447.