### PR TITLE
fix(devcontainer): bump docker-in-docker, introduce lockfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/anaconda:1-3
+FROM mcr.microsoft.com/devcontainers/anaconda:1.3.22-3
 
 # Install dependencies necessary to build Singularity
 RUN sudo apt-get update && sudo apt-get install -y \

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:4": {
+      "version": "4.0.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5",
+      "integrity": "sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5"
+    },
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.3.4",
+      "resolved": "ghcr.io/devcontainers/features/go@sha256:d85e921f91b41340055bb12b325d9d551170ed04b3b832e33530bf42f167c032",
+      "integrity": "sha256:d85e921f91b41340055bb12b325d9d551170ed04b3b832e33530bf42f167c032"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 		"dockerfile": "Dockerfile"
 	},
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:4": {},
 		// For building singularity
 		"ghcr.io/devcontainers/features/go:1": {}
 	},


### PR DESCRIPTION
[A PR was opened which fixed docker-in-docker for Ubuntu 26.04](https://github.com/devcontainers/features/pull/1637), which was merged on May 12th and was a minor version bump for docker-in-docker version 2 (the version of docker-in-docker we use), but [this caused a regression on Ubuntu/**Debian** backends for hosts whose kernel does not load the `ip_tables` kernel module by default (e.g. RHEL-based distributions like Fedora)](https://github.com/devcontainers/features/issues/1659). Our anaconda base image happens to be a Debian-based image, and I happen to be running on a host which does not load the `ip_tables` kernel module by default.

We fix this by both:
1. Bumping docker-in-docker to address the immediate issue.
2. Adding an associated lockfile which pins devcontainer features, while also pinning the base anaconda image version, to make sure issues of this sort never happen again.

_Reviewers: Make sure to test this in a devcontainer locally/in a codespace as well to make sure this works,_ though this issue shouldn't & doesn't seem to affect codespaces.